### PR TITLE
changed db ddl scripts

### DIFF
--- a/src/main/java/com/example/universe/simulator/entityservice/entities/Moon.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/entities/Moon.java
@@ -12,6 +12,6 @@ import javax.persistence.ManyToOne;
 public class Moon extends SpaceEntity {
 
     @ManyToOne
-    @JoinColumn(name = "planet_id", referencedColumnName = "id", nullable = false)
+    @JoinColumn(nullable = false)
     private Planet planet;
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/entities/Planet.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/entities/Planet.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class Planet extends SpaceEntity {
 
     @ManyToOne
-    @JoinColumn(name = "star_id", referencedColumnName = "id", nullable = false)
+    @JoinColumn(nullable = false)
     private Star star;
 
     @OneToMany(mappedBy = "planet")

--- a/src/main/java/com/example/universe/simulator/entityservice/entities/SpaceEntity.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/entities/SpaceEntity.java
@@ -3,7 +3,6 @@ package com.example.universe.simulator.entityservice.entities;
 import lombok.Getter;
 import lombok.Setter;
 
-
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -27,5 +26,4 @@ public abstract class SpaceEntity {
 
     @Version
     private long version;
-
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/entities/Star.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/entities/Star.java
@@ -3,7 +3,6 @@ package com.example.universe.simulator.entityservice.entities;
 import lombok.Getter;
 import lombok.Setter;
 
-
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -15,7 +14,7 @@ import java.util.Set;
 public class Star extends SpaceEntity {
 
     @ManyToOne
-    @JoinColumn(name = "galaxy_id", referencedColumnName = "id", nullable = false)
+    @JoinColumn(nullable = false)
     private Galaxy galaxy;
 
     @OneToMany(mappedBy = "star")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-#datasource - postgres
+#datasource
 spring.datasource.url=jdbc:postgresql://${postgres-host}:${postgres-port}/entity-service
 spring.datasource.username=${postgres-user}
 spring.datasource.password=${postgres-password}

--- a/src/main/resources/db/changelog/scripts/000-create-galaxy.sql
+++ b/src/main/resources/db/changelog/scripts/000-create-galaxy.sql
@@ -1,8 +1,6 @@
-CREATE TABLE public.galaxy
+create table galaxy
 (
-    id        uuid         NOT NULL,
-    "name"    varchar(255) NOT NULL,
-    "version" int8         NOT NULL,
-    CONSTRAINT galaxy_pkey PRIMARY KEY (id),
-    CONSTRAINT uk_q68vq5d83xit86g12ls0ul2uq UNIQUE (name)
+    id      uuid         not null constraint galaxy_pkey primary key,
+    name    varchar(255) not null constraint uk_q68vq5d83xit86g12ls0ul2uq unique,
+    version bigint       not null
 );

--- a/src/main/resources/db/changelog/scripts/001-create-star.sql
+++ b/src/main/resources/db/changelog/scripts/001-create-star.sql
@@ -1,10 +1,7 @@
-CREATE TABLE public.star
+create table star
 (
-    id        uuid         NOT NULL,
-    "name"    varchar(255) NOT NULL,
-    "version" int8         NOT NULL,
-    galaxy_id uuid         NOT NULL,
-    CONSTRAINT star_pkey PRIMARY KEY (id),
-    CONSTRAINT uk_64qlrdcru0rp18k6u1bs6feav UNIQUE (name),
-    CONSTRAINT fkol8sl9hdlkm9u7pv4154dbx1g FOREIGN KEY (galaxy_id) REFERENCES galaxy (id)
+    id        uuid         not null constraint star_pkey primary key,
+    name      varchar(255) not null constraint uk_64qlrdcru0rp18k6u1bs6feav unique,
+    version   bigint       not null,
+    galaxy_id uuid         not null constraint fkol8sl9hdlkm9u7pv4154dbx1g references galaxy
 );

--- a/src/main/resources/db/changelog/scripts/002-create-planet.sql
+++ b/src/main/resources/db/changelog/scripts/002-create-planet.sql
@@ -1,10 +1,7 @@
-CREATE TABLE public.planet
+create table planet
 (
-    id        uuid         NOT NULL,
-    "name"    varchar(255) NOT NULL,
-    "version" int8         NOT NULL,
-    star_id   uuid         NOT NULL,
-    CONSTRAINT planet_pkey PRIMARY KEY (id),
-    CONSTRAINT uk_dhelj2sd5e5spyo2flmdhxo6o UNIQUE (name),
-    CONSTRAINT fkc4fuaxedn05182lfgl6jadaqi FOREIGN KEY (star_id) REFERENCES star (id)
+    id      uuid         not null constraint planet_pkey primary key,
+    name    varchar(255) not null constraint uk_dhelj2sd5e5spyo2flmdhxo6o unique,
+    version bigint       not null,
+    star_id uuid         not null constraint fkc4fuaxedn05182lfgl6jadaqi references star
 );

--- a/src/main/resources/db/changelog/scripts/003-create-moon.sql
+++ b/src/main/resources/db/changelog/scripts/003-create-moon.sql
@@ -1,10 +1,7 @@
-CREATE TABLE public.moon
+create table moon
 (
-    id        uuid         NOT NULL,
-    "name"    varchar(255) NOT NULL,
-    "version" int8         NOT NULL,
-    planet_id uuid         NOT NULL,
-    CONSTRAINT moon_pkey PRIMARY KEY (id),
-    CONSTRAINT uk_avhv0qk9t09ywn3hgd59obxaa UNIQUE (name),
-    CONSTRAINT fki92drmat85orx06ht6nq5t1a4 FOREIGN KEY (planet_id) REFERENCES planet (id)
+    id        uuid         not null constraint moon_pkey primary key,
+    name      varchar(255) not null constraint uk_avhv0qk9t09ywn3hgd59obxaa unique,
+    version   bigint       not null,
+    planet_id uuid         not null constraint fki92drmat85orx06ht6nq5t1a4 references planet
 );


### PR DESCRIPTION
NB: The change is required for H2 migrations to work.

- fixed sql scripts to a more generic version
- removed unnecessary @JoinColumn arguments in entities
- removed postgres label from datasource in application.properties