### PR TITLE
added galaxy integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencyManagement {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     runtimeOnly 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     runtimeOnly 'org.springframework.cloud:spring-cloud-starter-vault-config'
     runtimeOnly 'org.liquibase:liquibase-core'
@@ -42,6 +41,5 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'com.h2database:h2'
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/entities/Galaxy.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/entities/Galaxy.java
@@ -7,16 +7,10 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import java.util.Set;
 
 @Entity
 @Getter @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder
-public class Galaxy extends SpaceEntity {
-
-    @OneToMany(mappedBy = "galaxy")
-    private Set<Star> stars;
-}
+public class Galaxy extends SpaceEntity {}

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/ErrorCodeType.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/ErrorCodeType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCodeType {
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST),
+    ENTITY_MODIFIED(HttpStatus.CONFLICT),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR),
     WRONG_HTTP_METHOD(HttpStatus.METHOD_NOT_ALLOWED);

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/ErrorCodeType.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/ErrorCodeType.java
@@ -8,11 +8,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCodeType {
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST),
     ENTITY_MODIFIED(HttpStatus.CONFLICT),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND),
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR),
-    WRONG_HTTP_METHOD(HttpStatus.METHOD_NOT_ALLOWED);
+    INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST),
+    INVALID_HTTP_METHOD(HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST),
+    INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
@@ -23,18 +23,24 @@ class RestExceptionHandler {
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
     }
 
-    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    private ResponseEntity<RestErrorResponse> handleHttpRequestMethodNotSupportedException() {
-        return buildErrorResponse(ErrorCodeType.WRONG_HTTP_METHOD);
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    private ResponseEntity<RestErrorResponse> handleHttpMediaTypeNotSupportedException() {
+        return buildErrorResponse(ErrorCodeType.INVALID_CONTENT_TYPE);
     }
 
-    @ExceptionHandler({
-            HttpMediaTypeNotSupportedException.class,
-            HttpMessageNotReadableException.class,
-            MethodArgumentTypeMismatchException.class
-    })
-    private ResponseEntity<RestErrorResponse> handleBadRequestException() {
-        return buildErrorResponse(ErrorCodeType.BAD_REQUEST);
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    private ResponseEntity<RestErrorResponse> handleHttpMessageNotReadableException() {
+        return buildErrorResponse(ErrorCodeType.INVALID_REQUEST_BODY);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    private ResponseEntity<RestErrorResponse> handleHttpRequestMethodNotSupportedException() {
+        return buildErrorResponse(ErrorCodeType.INVALID_HTTP_METHOD);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    private ResponseEntity<RestErrorResponse> handleMethodArgumentTypeMismatchException() {
+        return buildErrorResponse(ErrorCodeType.INVALID_REQUEST_PARAMETER);
     }
 
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
@@ -2,6 +2,8 @@ package com.example.universe.simulator.entityservice.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -26,9 +28,18 @@ class RestExceptionHandler {
         return buildErrorResponse(ErrorCodeType.WRONG_HTTP_METHOD);
     }
 
-    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class})
+    @ExceptionHandler({
+            HttpMediaTypeNotSupportedException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class
+    })
     private ResponseEntity<RestErrorResponse> handleBadRequestException() {
         return buildErrorResponse(ErrorCodeType.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    private ResponseEntity<RestErrorResponse> handleObjectOptimisticLockingFailureException() {
+        return buildErrorResponse(ErrorCodeType.ENTITY_MODIFIED);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/AbstractIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/AbstractIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.example.universe.simulator.entityservice.integration;
 
-import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
+import com.example.universe.simulator.entityservice.unit.AbstractMockMvcTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,4 +8,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-public abstract class AbstractIntegrationTest extends AbstractWebMvcTest {}
+public abstract class AbstractIntegrationTest extends AbstractMockMvcTest {}

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/AbstractIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/AbstractIntegrationTest.java
@@ -1,0 +1,11 @@
+package com.example.universe.simulator.entityservice.integration;
+
+import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+public abstract class AbstractIntegrationTest extends AbstractWebMvcTest {}

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
@@ -1,0 +1,146 @@
+package com.example.universe.simulator.entityservice.integration;
+
+import com.example.universe.simulator.entityservice.entities.Galaxy;
+import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+public class GalaxyIntegrationTest extends AbstractIntegrationTest {
+
+    @Test
+    void test() throws Exception {
+        //-----should return empty list-----
+
+        //when
+        MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+
+        List<Galaxy> resultList = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
+        assertTrue(resultList.isEmpty());
+
+        //-----should add entity-----
+
+        //given
+        Galaxy entity = Galaxy.builder().name("name").build();
+        //when
+        response = mockMvc.perform(post("/galaxy/add")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(entity))
+        ).andReturn().getResponse();
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+
+        Galaxy addedEntity = objectMapper.readValue(response.getContentAsString(), Galaxy.class);
+        assertNotNull(addedEntity.getId());
+        assertEquals(entity.getName(), addedEntity.getName());
+        assertEquals(0, addedEntity.getVersion());
+
+        //-----should return list with 1 element-----
+
+        //when
+        response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+
+        resultList = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
+        assertEquals(1, resultList.size());
+
+        //-----should return entity that was added-----
+
+        //when
+        UUID id = addedEntity.getId();
+        response = mockMvc.perform(get("/galaxy/get/{id}", id)).andReturn().getResponse();
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+
+        Galaxy resultEntity = objectMapper.readValue(response.getContentAsString(), Galaxy.class);
+        assertEquals(addedEntity, resultEntity);
+
+        //-----should update entity-----
+
+        //given
+        entity = Galaxy.builder().id(id).name("newName").build();
+        //when
+        response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(entity))
+        ).andReturn().getResponse();
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+
+        Galaxy updatedEntity = objectMapper.readValue(response.getContentAsString(), Galaxy.class);
+        assertEquals(id, updatedEntity.getId());
+        assertEquals(entity.getName(), updatedEntity.getName());
+        assertEquals(1, updatedEntity.getVersion());
+
+        //-----should throw entity modified exception on update-----
+
+        //given
+        entity = Galaxy.builder().id(id).name("newName").build();
+        //when
+        response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(entity))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.ENTITY_MODIFIED);
+
+        //-----should delete entity-----
+
+        //when
+        response = mockMvc.perform(delete("/galaxy/delete/{id}", id)).andReturn().getResponse();
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+
+        //-----should return empty list-----
+
+        //when
+        response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+
+        resultList = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
+        assertTrue(resultList.isEmpty());
+        
+        //-----should throw entity not found exception on get-----
+        
+        //when
+        response = mockMvc.perform(get("/galaxy/get/{id}", id)).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.ENTITY_NOT_FOUND);
+
+        //-----should throw entity not found exception on update-----
+
+        //given
+        entity = Galaxy.builder().id(id).build();
+        //when
+        response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(entity))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.ENTITY_NOT_FOUND);
+
+        //-----should throw entity not found exception on delete-----
+
+        //when
+        mockMvc.perform(delete("/galaxy/delete/{id}", id)).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.ENTITY_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/AbstractMockMvcTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/AbstractMockMvcTest.java
@@ -11,7 +11,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ActiveProfiles("test")
-public abstract class AbstractWebMvcTest {
+public abstract class AbstractMockMvcTest {
 
     @Autowired
     protected MockMvc mockMvc;

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/GalaxyControllerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/GalaxyControllerTest.java
@@ -5,7 +5,7 @@ import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
-import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
+import com.example.universe.simulator.entityservice.unit.AbstractMockMvcTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @WebMvcTest(GalaxyController.class)
-public class GalaxyControllerTest extends AbstractWebMvcTest {
+public class GalaxyControllerTest extends AbstractMockMvcTest {
 
     @MockBean
     private GalaxyService service;

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
@@ -4,7 +4,7 @@ import com.example.universe.simulator.entityservice.controllers.GalaxyController
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
-import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
+import com.example.universe.simulator.entityservice.unit.AbstractMockMvcTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -26,19 +26,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
  * Generic RestExceptionHandler cases are tested using GalaxyController.
  */
 @WebMvcTest(GalaxyController.class)
-public class RestExceptionHandlerTest extends AbstractWebMvcTest {
+public class RestExceptionHandlerTest extends AbstractMockMvcTest {
 
     @MockBean
     private GalaxyService service;
-
-    @Test
-    void testWrongHttpMethod() throws Exception {
-        //when
-        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/get-list")).andReturn().getResponse();
-        //then
-        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.WRONG_HTTP_METHOD);
-        then(service).should(never()).getList();
-    }
 
     @Test
     void testHttpMediaTypeNotSupported() throws Exception {
@@ -49,7 +40,7 @@ public class RestExceptionHandlerTest extends AbstractWebMvcTest {
                 .content(objectMapper.writeValueAsString(entity))
         ).andReturn().getResponse();
         //then
-        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.BAD_REQUEST);
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.INVALID_CONTENT_TYPE);
         then(service).should(never()).add(entity);
     }
 
@@ -58,7 +49,16 @@ public class RestExceptionHandlerTest extends AbstractWebMvcTest {
         //when
         MockHttpServletResponse response = mockMvc.perform(post("/galaxy/add")).andReturn().getResponse();
         //then
-        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.BAD_REQUEST);
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.INVALID_REQUEST_BODY);
+    }
+
+    @Test
+    void testHttpRequestMethodNotSupported() throws Exception {
+        //when
+        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/get-list")).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.INVALID_HTTP_METHOD);
+        then(service).should(never()).getList();
     }
 
     @Test
@@ -68,7 +68,7 @@ public class RestExceptionHandlerTest extends AbstractWebMvcTest {
         //when
         MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get/{id}", id)).andReturn().getResponse();
         //then
-        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.BAD_REQUEST);
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.INVALID_REQUEST_PARAMETER);
     }
 
     @Test

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
@@ -1,19 +1,26 @@
 package com.example.universe.simulator.entityservice.unit.exception;
 
 import com.example.universe.simulator.entityservice.controllers.GalaxyController;
+import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
 import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 /**
  * Generic RestExceptionHandler cases are tested using GalaxyController.
@@ -31,6 +38,19 @@ public class RestExceptionHandlerTest extends AbstractWebMvcTest {
         //then
         verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.WRONG_HTTP_METHOD);
         then(service).should(never()).getList();
+    }
+
+    @Test
+    void testHttpMediaTypeNotSupported() throws Exception {
+        //given
+        Galaxy entity = Galaxy.builder().name("name").build();
+        //when
+        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/add")
+                .content(objectMapper.writeValueAsString(entity))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.BAD_REQUEST);
+        then(service).should(never()).add(entity);
     }
 
     @Test
@@ -52,6 +72,22 @@ public class RestExceptionHandlerTest extends AbstractWebMvcTest {
     }
 
     @Test
+    void testObjectOptimisticLockingFailure() throws Exception {
+        //given
+        UUID id = UUID.randomUUID();
+        Galaxy entity = Galaxy.builder().id(id).name("name").build();
+        given(service.update(any())).willThrow(ObjectOptimisticLockingFailureException.class);
+        //when
+        MockHttpServletResponse response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(entity))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.ENTITY_MODIFIED);
+        then(service).should().update(entity);
+    }
+
+    @Test
     void testUnknownException() throws Exception {
         //given
         given(service.getList()).willThrow(RuntimeException.class);
@@ -59,5 +95,6 @@ public class RestExceptionHandlerTest extends AbstractWebMvcTest {
         MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
         //then
         verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.SERVER_ERROR);
+        then(service).should().getList();
     }
 }


### PR DESCRIPTION
- removed stars collection from Galaxy
- removed reactive web dependencies until needed
- added new handlers in RestExceptionHandler
- removed BAD_REQUEST error code
- added new error codes
- renamed WRONG_HTTP_METHOD error code to INVALID_HTTP_METHOD and changed it's http status to BAD_REQUEST
- split handleBadRequestException method into separate methods for better error reporting in RestExceptionHandler
- renamed AbstractWebMvcTest to AbstractMockMvcTest
- added AbstractIntegrationTest
- added GalaxyIntegrationTest
- renamed testWrongHttpMethod method to testHttpRequestMethodNotSupported in RestExceptionHandlerTest
- added new handler tests in RestExceptionHandlerTest
- added service call verification in testUnknownException test in RestExceptionHandlerTest