### PR TITLE
added galaxy input validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.4.1'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+    id 'org.springframework.boot' version '2.4.1'
 }
 
 group = 'com.example.universe.simulator'
@@ -33,6 +33,7 @@ dependencyManagement {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.modelmapper:modelmapper:2.3.9'
     runtimeOnly 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     runtimeOnly 'org.springframework.cloud:spring-cloud-starter-vault-config'
     runtimeOnly 'org.liquibase:liquibase-core'

--- a/src/main/java/com/example/universe/simulator/entityservice/config/BeanConfig.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/config/BeanConfig.java
@@ -1,0 +1,14 @@
+package com.example.universe.simulator.entityservice.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanConfig {
+
+    @Bean
+    ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
@@ -29,17 +29,17 @@ public class GalaxyController {
     private final GalaxyService service;
 
     @GetMapping("get-list")
-    public List<GalaxyDto> getList() {
+    private List<GalaxyDto> getList() {
         return modelMapper.map(service.getList(), new TypeToken<List<GalaxyDto>>() {}.getType());
     }
 
     @GetMapping("get/{id}")
-    public GalaxyDto get(@PathVariable UUID id) throws AppException {
+    private GalaxyDto get(@PathVariable UUID id) throws AppException {
         return modelMapper.map(service.get(id), GalaxyDto.class);
     }
 
     @PostMapping("add")
-    public GalaxyDto add(@RequestBody GalaxyDto dto) throws AppException {
+    private GalaxyDto add(@RequestBody GalaxyDto dto) throws AppException {
         dto.validate(false);
 
         Galaxy entity = modelMapper.map(dto, Galaxy.class);
@@ -48,7 +48,7 @@ public class GalaxyController {
     }
 
     @PutMapping("update")
-    public GalaxyDto update(@RequestBody GalaxyDto dto) throws AppException {
+    private GalaxyDto update(@RequestBody GalaxyDto dto) throws AppException {
         dto.validate(true);
 
         Galaxy entity = modelMapper.map(dto, Galaxy.class);
@@ -57,7 +57,7 @@ public class GalaxyController {
     }
 
     @DeleteMapping("delete/{id}")
-    public void delete(@PathVariable UUID id) throws AppException {
+    private void delete(@PathVariable UUID id) throws AppException {
         service.delete(id);
     }
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
@@ -1,9 +1,12 @@
 package com.example.universe.simulator.entityservice.controllers;
 
+import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeToken;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,26 +24,36 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GalaxyController {
 
+    private final ModelMapper modelMapper;
+
     private final GalaxyService service;
 
     @GetMapping("get-list")
-    public List<Galaxy> getList() {
-        return service.getList();
+    public List<GalaxyDto> getList() {
+        return modelMapper.map(service.getList(), new TypeToken<List<GalaxyDto>>() {}.getType());
     }
 
     @GetMapping("get/{id}")
-    public Galaxy get(@PathVariable UUID id) throws AppException {
-        return service.get(id);
+    public GalaxyDto get(@PathVariable UUID id) throws AppException {
+        return modelMapper.map(service.get(id), GalaxyDto.class);
     }
 
     @PostMapping("add")
-    public Galaxy add(@RequestBody Galaxy entity) {
-        return service.add(entity);
+    public GalaxyDto add(@RequestBody GalaxyDto dto) throws AppException {
+        dto.validate(false);
+
+        Galaxy entity = modelMapper.map(dto, Galaxy.class);
+
+        return modelMapper.map(service.add(entity), GalaxyDto.class);
     }
 
     @PutMapping("update")
-    public Galaxy update(@RequestBody Galaxy entity) throws AppException {
-        return service.update(entity);
+    public GalaxyDto update(@RequestBody GalaxyDto dto) throws AppException {
+        dto.validate(true);
+
+        Galaxy entity = modelMapper.map(dto, Galaxy.class);
+
+        return modelMapper.map(service.update(entity), GalaxyDto.class);
     }
 
     @DeleteMapping("delete/{id}")

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/GalaxyDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/GalaxyDto.java
@@ -1,0 +1,20 @@
+package com.example.universe.simulator.entityservice.dtos;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter @Setter
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class GalaxyDto extends SpaceEntityDto {
+
+    @Override
+    protected void validateDtoSpecificFields() {}
+
+    @Override
+    protected void fixDtoSpecificDirtyFields() {}
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/SpaceEntityDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/SpaceEntityDto.java
@@ -1,0 +1,61 @@
+package com.example.universe.simulator.entityservice.dtos;
+
+import com.example.universe.simulator.entityservice.exception.AppException;
+import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
+import com.example.universe.simulator.entityservice.utils.Utils;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Getter @Setter
+@NoArgsConstructor
+@EqualsAndHashCode
+@SuperBuilder
+abstract class SpaceEntityDto {
+
+    private UUID id;
+
+    private String name;
+
+    private Long version;
+
+    public void validate(boolean isUpdate) throws AppException {
+        validateCommonFields(isUpdate);
+        validateDtoSpecificFields();
+
+        fixCommonDirtyFields(isUpdate);
+        fixDtoSpecificDirtyFields();
+    }
+
+    private void validateCommonFields(boolean isUpdate) throws AppException {
+        if (isUpdate && Objects.isNull(id)) {
+            throw new AppException(ErrorCodeType.MISSING_PARAMETER_ID);
+        }
+
+        if (Utils.isNullOrBlank(name)) {
+            throw new AppException(ErrorCodeType.MISSING_PARAMETER_NAME);
+        }
+
+        if (isUpdate && Objects.isNull(version)) {
+            throw new AppException(ErrorCodeType.MISSING_PARAMETER_VERSION);
+        }
+    }
+
+    private void fixCommonDirtyFields(boolean isUpdate) {
+        if (!isUpdate) {
+            id = null;
+            version = null;
+        }
+
+        name = name.strip();
+    }
+
+    protected abstract void validateDtoSpecificFields() throws AppException;
+
+    protected abstract void fixDtoSpecificDirtyFields();
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/entities/SpaceEntity.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/entities/SpaceEntity.java
@@ -14,7 +14,7 @@ import javax.persistence.Version;
 import java.util.UUID;
 
 /**
- * parent for all space objects
+ * Parent for all space objects.
  */
 @MappedSuperclass
 @Getter @Setter

--- a/src/main/java/com/example/universe/simulator/entityservice/entities/SpaceEntity.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/entities/SpaceEntity.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @EqualsAndHashCode
 @SuperBuilder
-public abstract class SpaceEntity {
+abstract class SpaceEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/ErrorCodeType.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/ErrorCodeType.java
@@ -8,12 +8,16 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCodeType {
 
+    ENTITY_EXISTS(HttpStatus.CONFLICT),
     ENTITY_MODIFIED(HttpStatus.CONFLICT),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND),
     INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST),
     INVALID_HTTP_METHOD(HttpStatus.BAD_REQUEST),
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST),
     INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST),
+    MISSING_PARAMETER_ID(HttpStatus.BAD_REQUEST),
+    MISSING_PARAMETER_NAME(HttpStatus.BAD_REQUEST),
+    MISSING_PARAMETER_VERSION(HttpStatus.BAD_REQUEST),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/RestErrorResponse.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/RestErrorResponse.java
@@ -14,7 +14,7 @@ public class RestErrorResponse {
     private int status;
     private ErrorCodeType error;
 
-    public RestErrorResponse(ErrorCodeType errorCode) {
+    RestErrorResponse(ErrorCodeType errorCode) {
         this.error = errorCode;
         timestamp = Instant.now();
         status = errorCode.getHttpStatus().value();

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.universe.simulator.entityservice.exception;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -23,26 +24,37 @@ class RestExceptionHandler {
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
     }
 
+    //thrown when some db unique field constraint is violated
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    private ResponseEntity<RestErrorResponse> handleDataIntegrityViolationException() {
+        return buildErrorResponse(ErrorCodeType.ENTITY_EXISTS);
+    }
+
+    //thrown when content type is not specified or is something other than json
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
     private ResponseEntity<RestErrorResponse> handleHttpMediaTypeNotSupportedException() {
         return buildErrorResponse(ErrorCodeType.INVALID_CONTENT_TYPE);
     }
 
+    //thrown when request body is missing or cannot be deserialized
     @ExceptionHandler(HttpMessageNotReadableException.class)
     private ResponseEntity<RestErrorResponse> handleHttpMessageNotReadableException() {
         return buildErrorResponse(ErrorCodeType.INVALID_REQUEST_BODY);
     }
 
+    //thrown when wrong http method is used
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     private ResponseEntity<RestErrorResponse> handleHttpRequestMethodNotSupportedException() {
         return buildErrorResponse(ErrorCodeType.INVALID_HTTP_METHOD);
     }
 
+    //thrown when request parameter cannot be processed
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     private ResponseEntity<RestErrorResponse> handleMethodArgumentTypeMismatchException() {
         return buildErrorResponse(ErrorCodeType.INVALID_REQUEST_PARAMETER);
     }
 
+    //thrown when request entity version does not match db version
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
     private ResponseEntity<RestErrorResponse> handleObjectOptimisticLockingFailureException() {
         return buildErrorResponse(ErrorCodeType.ENTITY_MODIFIED);

--- a/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/exception/RestExceptionHandler.java
@@ -24,7 +24,7 @@ class RestExceptionHandler {
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
     }
 
-    //thrown when some db unique field constraint is violated
+    //thrown when database unique field constraint is violated
     @ExceptionHandler(DataIntegrityViolationException.class)
     private ResponseEntity<RestErrorResponse> handleDataIntegrityViolationException() {
         return buildErrorResponse(ErrorCodeType.ENTITY_EXISTS);

--- a/src/main/java/com/example/universe/simulator/entityservice/utils/Utils.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/utils/Utils.java
@@ -1,0 +1,12 @@
+package com.example.universe.simulator.entityservice.utils;
+
+import java.util.Objects;
+
+public final class Utils {
+
+    private Utils() {}
+
+    public static boolean isNullOrBlank(String str) {
+        return Objects.isNull(str) || str.isBlank();
+    }
+}

--- a/src/test/java/com/example/universe/simulator/entityservice/AbstractMockMvcTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/AbstractMockMvcTest.java
@@ -1,4 +1,4 @@
-package com.example.universe.simulator.entityservice.unit;
+package com.example.universe.simulator.entityservice;
 
 import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
 import com.example.universe.simulator.entityservice.exception.RestErrorResponse;

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/AbstractIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/AbstractIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.example.universe.simulator.entityservice.integration;
 
-import com.example.universe.simulator.entityservice.unit.AbstractMockMvcTest;
+import com.example.universe.simulator.entityservice.AbstractMockMvcTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,4 +8,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-public abstract class AbstractIntegrationTest extends AbstractMockMvcTest {}
+abstract class AbstractIntegrationTest extends AbstractMockMvcTest {}

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/AbstractWebMvcTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/AbstractWebMvcTest.java
@@ -1,0 +1,14 @@
+package com.example.universe.simulator.entityservice.unit;
+
+import com.example.universe.simulator.entityservice.AbstractMockMvcTest;
+import com.example.universe.simulator.entityservice.config.BeanConfig;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import(BeanConfig.class)
+public abstract class AbstractWebMvcTest extends AbstractMockMvcTest {
+
+    @Autowired
+    protected ModelMapper modelMapper;
+}

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/GalaxyControllerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/GalaxyControllerTest.java
@@ -1,12 +1,15 @@
 package com.example.universe.simulator.entityservice.unit.controllers;
 
 import com.example.universe.simulator.entityservice.controllers.GalaxyController;
+import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
-import com.example.universe.simulator.entityservice.unit.AbstractMockMvcTest;
+import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
+import com.example.universe.simulator.entityservice.utils.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.modelmapper.TypeToken;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -21,13 +24,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @WebMvcTest(GalaxyController.class)
-public class GalaxyControllerTest extends AbstractMockMvcTest {
+class GalaxyControllerTest extends AbstractWebMvcTest {
 
     @MockBean
     private GalaxyService service;
@@ -35,15 +39,18 @@ public class GalaxyControllerTest extends AbstractMockMvcTest {
     @Test
     void testGetList() throws Exception {
         //given
-        List<Galaxy> list = List.of(
+        List<Galaxy> entityList = List.of(
                 Galaxy.builder().name("name").build()
         );
-        given(service.getList()).willReturn(list);
+        List<GalaxyDto> dtoList = modelMapper.map(entityList, new TypeToken<List<GalaxyDto>>() {}.getType());
+
+        given(service.getList()).willReturn(entityList);
         //when
         MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
         //then
         assertEquals(HttpStatus.OK.value(), response.getStatus());
-        assertEquals(objectMapper.writeValueAsString(list), response.getContentAsString());
+        assertEquals(objectMapper.writeValueAsString(dtoList), response.getContentAsString());
+
         then(service).should().getList();
     }
 
@@ -64,41 +71,171 @@ public class GalaxyControllerTest extends AbstractMockMvcTest {
         //given
         UUID id = UUID.randomUUID();
         Galaxy entity = Galaxy.builder().name("name").build();
+        GalaxyDto dto = modelMapper.map(entity, GalaxyDto.class);
+
         given(service.get(any())).willReturn(entity);
         //when
         MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get/{id}", id)).andReturn().getResponse();
         //then
         assertEquals(HttpStatus.OK.value(), response.getStatus());
-        assertEquals(objectMapper.writeValueAsString(entity), response.getContentAsString());
+        assertEquals(objectMapper.writeValueAsString(dto), response.getContentAsString());
+
         then(service).should().get(id);
     }
 
     @Test
-    void testAdd() throws Exception {
+    void testAdd_validationFail() throws Exception {
+        //-----should fail validation on null name-----
+
         //given
-        Galaxy entity = Galaxy.builder().name("name").build();
+        GalaxyDto dto = TestUtils.buildSampleGalaxyDtoForAdd();
+        dto.setName(null);
+        //when
+        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/add")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_NAME);
+        then(service).should(never()).add(any());
+
+        //-----should fail validation on empty name-----
+
+        //given
+        dto = TestUtils.buildSampleGalaxyDtoForAdd();
+        dto.setName("");
+        //when
+        response = mockMvc.perform(post("/galaxy/add")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_NAME);
+        then(service).should(never()).add(any());
+
+        //-----should fail validation on blank name-----
+
+        //given
+        dto = TestUtils.buildSampleGalaxyDtoForAdd();
+        dto.setName(" ");
+        //when
+        response = mockMvc.perform(post("/galaxy/add")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_NAME);
+        then(service).should(never()).add(any());
+    }
+
+    @Test
+    void testAdd_dirtyFieldFixAndSuccessfulAdd() throws Exception {
+        //given
+        GalaxyDto inputDto = TestUtils.buildSampleGalaxyDtoForAdd();
+        Galaxy entity = modelMapper.map(inputDto, Galaxy.class);
+        GalaxyDto resultDto = modelMapper.map(entity, GalaxyDto.class);
+        
+        //dirty input
+        inputDto.setId(UUID.randomUUID());
+        inputDto.setName(" name ");
+        inputDto.setVersion(1L);
+
         given(service.add(any())).willReturn(entity);
         //when
         MockHttpServletResponse response = mockMvc.perform(post("/galaxy/add")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(entity))
+                .content(objectMapper.writeValueAsString(inputDto))
         ).andReturn().getResponse();
         //then
         assertEquals(HttpStatus.OK.value(), response.getStatus());
-        assertEquals(objectMapper.writeValueAsString(entity), response.getContentAsString());
+        assertEquals(objectMapper.writeValueAsString(resultDto), response.getContentAsString());
+
         then(service).should().add(entity);
+    }
+
+    @Test
+    void testUpdate_validationFail() throws Exception {
+        //-----should fail validation on null id-----
+
+        //given
+        GalaxyDto dto = new GalaxyDto();
+        //when
+        MockHttpServletResponse response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_ID);
+        then(service).should(never()).update(any());
+
+        //-----should fail validation on null name-----
+
+        //given
+        dto = TestUtils.buildSampleGalaxyDtoForUpdate();
+        dto.setName(null);
+        //when
+        response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_NAME);
+        then(service).should(never()).update(any());
+
+        //-----should fail validation on empty name-----
+
+        //given
+        dto = TestUtils.buildSampleGalaxyDtoForUpdate();
+        dto.setName("");
+        //when
+        response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_NAME);
+        then(service).should(never()).update(any());
+
+        //-----should fail validation on blank name-----
+
+        //given
+        dto = TestUtils.buildSampleGalaxyDtoForUpdate();
+        dto.setName(" ");
+        //when
+        response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_NAME);
+        then(service).should(never()).update(any());
+
+        //-----should fail validation on null version-----
+
+        //given
+        dto = TestUtils.buildSampleGalaxyDtoForUpdate();
+        dto.setVersion(null);
+        //when
+        response = mockMvc.perform(put("/galaxy/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+        ).andReturn().getResponse();
+        //then
+        verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.MISSING_PARAMETER_VERSION);
+        then(service).should(never()).update(any());
     }
 
     @Test
     void testUpdate_idNotFound() throws Exception {
         //given
-        UUID id = UUID.randomUUID();
-        Galaxy entity = Galaxy.builder().id(id).name("name").build();
+        GalaxyDto dto = TestUtils.buildSampleGalaxyDtoForUpdate();
+        Galaxy entity = modelMapper.map(dto, Galaxy.class);
+
         given(service.update(any())).willThrow(new AppException(ErrorCodeType.ENTITY_NOT_FOUND));
         //when
         MockHttpServletResponse response = mockMvc.perform(put("/galaxy/update")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(entity))
+                .content(objectMapper.writeValueAsString(dto))
         ).andReturn().getResponse();
         //then
         verifyRestErrorResponse(response.getContentAsString(), ErrorCodeType.ENTITY_NOT_FOUND);
@@ -106,19 +243,25 @@ public class GalaxyControllerTest extends AbstractMockMvcTest {
     }
 
     @Test
-    void testUpdate_successfulUpdate() throws Exception {
+    void testUpdate_dirtyFieldFixAndSuccessfulUpdate() throws Exception {
         //given
-        UUID id = UUID.randomUUID();
-        Galaxy entity = Galaxy.builder().id(id).name("name").build();
+        GalaxyDto inputDto = TestUtils.buildSampleGalaxyDtoForUpdate();
+        Galaxy entity = modelMapper.map(inputDto, Galaxy.class);
+        GalaxyDto resultDto = modelMapper.map(entity, GalaxyDto.class);
+
+        //dirty input
+        inputDto.setName(" name ");
+
         given(service.update(any())).willReturn(entity);
         //when
         MockHttpServletResponse response = mockMvc.perform(put("/galaxy/update")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(entity))
+                .content(objectMapper.writeValueAsString(inputDto))
         ).andReturn().getResponse();
         //then
         assertEquals(HttpStatus.OK.value(), response.getStatus());
-        assertEquals(objectMapper.writeValueAsString(entity), response.getContentAsString());
+        assertEquals(objectMapper.writeValueAsString(resultDto), response.getContentAsString());
+
         then(service).should().update(entity);
     }
 

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/GalaxyServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/GalaxyServiceTest.java
@@ -23,7 +23,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
-public class GalaxyServiceTest {
+class GalaxyServiceTest {
 
     @Mock
     private GalaxyRepository repository;
@@ -62,6 +62,7 @@ public class GalaxyServiceTest {
         //given
         UUID id = UUID.randomUUID();
         Galaxy entity = Galaxy.builder().name("name").build();
+
         given(repository.findById(any())).willReturn(Optional.of(entity));
         //when
         Galaxy result = service.get(id);
@@ -87,6 +88,7 @@ public class GalaxyServiceTest {
         //given
         UUID id = UUID.randomUUID();
         Galaxy entity = Galaxy.builder().id(id).name("name").build();
+
         given(repository.findById(any())).willReturn(Optional.empty());
         //then
         AppException exception = assertThrows(AppException.class, () -> service.update(entity));
@@ -101,12 +103,14 @@ public class GalaxyServiceTest {
         //given
         UUID id = UUID.randomUUID();
         Galaxy entity = Galaxy.builder().id(id).name("name").build();
+
         given(repository.findById(any())).willReturn(Optional.of(entity));
         given(repository.save(any())).willReturn(entity);
         //when
         Galaxy result = service.update(entity);
         //then
         assertEquals(entity, result);
+
         then(repository).should().findById(id);
         then(repository).should().save(entity);
     }
@@ -129,6 +133,7 @@ public class GalaxyServiceTest {
         //given
         UUID id = UUID.randomUUID();
         Galaxy entity = Galaxy.builder().name("name").build();
+
         given(repository.findById(any())).willReturn(Optional.of(entity));
         //when
         service.delete(id);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/utils/UtilsTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/utils/UtilsTest.java
@@ -1,0 +1,39 @@
+package com.example.universe.simulator.entityservice.unit.utils;
+
+import com.example.universe.simulator.entityservice.utils.Utils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UtilsTest {
+
+    @Test
+    void testIsNullOrBlank() {
+        //when
+        boolean result = Utils.isNullOrBlank(null);
+        //then
+        assertTrue(result);
+
+        //given
+        String str = "";
+        //when
+        result = Utils.isNullOrBlank(str);
+        //then
+        assertTrue(result);
+
+        //given
+        str = " ";
+        //when
+        result = Utils.isNullOrBlank(str);
+        //then
+        assertTrue(result);
+
+        //given
+        str = "str";
+        //when
+        result = Utils.isNullOrBlank(str);
+        //then
+        assertFalse(result);
+    }
+}

--- a/src/test/java/com/example/universe/simulator/entityservice/utils/TestUtils.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/utils/TestUtils.java
@@ -1,0 +1,24 @@
+package com.example.universe.simulator.entityservice.utils;
+
+import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
+
+import java.util.UUID;
+
+public class TestUtils {
+
+    private TestUtils() {}
+
+    public static GalaxyDto buildSampleGalaxyDtoForAdd() {
+        return GalaxyDto.builder()
+                .name("name")
+                .build();
+    }
+
+    public static GalaxyDto buildSampleGalaxyDtoForUpdate() {
+        GalaxyDto result = buildSampleGalaxyDtoForAdd();
+        result.setId(UUID.randomUUID());
+        result.setVersion(0L);
+
+        return result;
+    }
+}

--- a/src/test/java/com/example/universe/simulator/entityservice/utils/TestUtils.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/utils/TestUtils.java
@@ -4,7 +4,7 @@ import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 
 import java.util.UUID;
 
-public class TestUtils {
+public final class TestUtils {
 
     private TestUtils() {}
 


### PR DESCRIPTION
- added input validation & fixes for galaxies
- added new error codes
- added SpaceEntityDto and GalaxyDto
- GalaxyController endpoints now accept and return GalaxyDto objects
- added modelmapper dependency
- added BeanConfig class
- added Utils class
- added comments for exceptions in RestExceptionHandler
- changed SpaceEntity visibility to package-private
- added TestUtils class
- added sample Galaxy objects creation in TestUtils
- added UtilsTest
- added AbstractWebMvcTest
- RestExceptionHandlerTest and GalaxyControllerTest now extend AbstractWebMvcTest
- moved AbstractMockMvcTest to root test package
- added second test case in testHttpMediaTypeNotSupported method in RestExceptionHandlerTest
- added missing service call checks in some methods in RestExceptionHandlerTest
- changed visibility of some test classes to package-private