### PR TITLE
added galaxy filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ out/
 .vscode/
 
 ### Application ###
+src/main/generated
 bootstrap-local.*
 application-local.*
 rebel.xml

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     runtimeOnly 'org.liquibase:liquibase-core'
     runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.hibernate:hibernate-jpamodelgen'
     annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/universe/simulator/entityservice/EntityServiceApplication.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/EntityServiceApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-class EntityServiceApplication {
+public class EntityServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(EntityServiceApplication.class, args);

--- a/src/main/java/com/example/universe/simulator/entityservice/EntityServiceApplication.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/EntityServiceApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class EntityServiceApplication {
+class EntityServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(EntityServiceApplication.class, args);

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
@@ -3,11 +3,14 @@ package com.example.universe.simulator.entityservice.controllers;
 import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
+import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
+import com.example.universe.simulator.entityservice.specifications.GalaxySpecification;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @RestController
@@ -28,9 +32,11 @@ public class GalaxyController {
 
     private final GalaxyService service;
 
-    @GetMapping("get-list")
-    private Page<GalaxyDto> getList(Pageable pageable) {
-        return service.getList(pageable)
+    @PostMapping("get-list")
+    private Page<GalaxyDto> getList(@RequestBody Optional<GalaxyFilter> filter, Pageable pageable) {
+        Specification<Galaxy> specification = filter.map(item -> new GalaxySpecification().getSpecification(item))
+                .orElse(null);
+        return service.getList(specification, pageable)
                 .map(item -> modelMapper.map(item, GalaxyDto.class));
     }
 

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/GalaxyDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/GalaxyDto.java
@@ -13,8 +13,8 @@ import lombok.experimental.SuperBuilder;
 public class GalaxyDto extends SpaceEntityDto {
 
     @Override
-    protected void validateDtoSpecificFields() {}
+    void validateDtoFields() {}
 
     @Override
-    protected void fixDtoSpecificDirtyFields() {}
+    void fixDtoDirtyFields() {}
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/MoonDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/MoonDto.java
@@ -20,7 +20,7 @@ public class MoonDto extends SpaceEntityDto {
     private PlanetDto planet;
 
     @Override
-    protected void validateDtoSpecificFields() throws AppException {
+    void validateDtoFields() throws AppException {
         if (Objects.isNull(planet)) {
             throw new AppException(ErrorCodeType.MISSING_PARAMETER_PLANET);
         }
@@ -30,5 +30,5 @@ public class MoonDto extends SpaceEntityDto {
     }
 
     @Override
-    protected void fixDtoSpecificDirtyFields() {}
+    void fixDtoDirtyFields() {}
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/PlanetDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/PlanetDto.java
@@ -20,7 +20,7 @@ public class PlanetDto extends SpaceEntityDto {
     private StarDto star;
 
     @Override
-    protected void validateDtoSpecificFields() throws AppException {
+    void validateDtoFields() throws AppException {
         if (Objects.isNull(star)) {
             throw new AppException(ErrorCodeType.MISSING_PARAMETER_STAR);
         }
@@ -30,5 +30,5 @@ public class PlanetDto extends SpaceEntityDto {
     }
 
     @Override
-    protected void fixDtoSpecificDirtyFields() {}
+    void fixDtoDirtyFields() {}
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/SpaceEntityDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/SpaceEntityDto.java
@@ -26,10 +26,10 @@ abstract class SpaceEntityDto {
 
     public void validate(boolean isUpdate) throws AppException {
         validateCommonFields(isUpdate);
-        validateDtoSpecificFields();
+        validateDtoFields();
 
         fixCommonDirtyFields(isUpdate);
-        fixDtoSpecificDirtyFields();
+        fixDtoDirtyFields();
     }
 
     private void validateCommonFields(boolean isUpdate) throws AppException {
@@ -53,7 +53,7 @@ abstract class SpaceEntityDto {
         name = name.strip();
     }
 
-    protected abstract void validateDtoSpecificFields() throws AppException;
+    abstract void validateDtoFields() throws AppException;
 
-    protected abstract void fixDtoSpecificDirtyFields();
+    abstract void fixDtoDirtyFields();
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/SpaceEntityDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/SpaceEntityDto.java
@@ -24,7 +24,7 @@ abstract class SpaceEntityDto {
 
     private Long version;
 
-    public void validate(boolean isUpdate) throws AppException {
+    public final void validate(boolean isUpdate) throws AppException {
         validateCommonFields(isUpdate);
         validateDtoFields();
 

--- a/src/main/java/com/example/universe/simulator/entityservice/dtos/StarDto.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/dtos/StarDto.java
@@ -20,7 +20,7 @@ public class StarDto extends SpaceEntityDto {
     private GalaxyDto galaxy;
 
     @Override
-    protected void validateDtoSpecificFields() throws AppException {
+    void validateDtoFields() throws AppException {
         if (Objects.isNull(galaxy)) {
             throw new AppException(ErrorCodeType.MISSING_PARAMETER_GALAXY);
         }
@@ -30,5 +30,5 @@ public class StarDto extends SpaceEntityDto {
     }
 
     @Override
-    protected void fixDtoSpecificDirtyFields() {}
+    void fixDtoDirtyFields() {}
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/GalaxyFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/GalaxyFilter.java
@@ -1,0 +1,11 @@
+package com.example.universe.simulator.entityservice.filters;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter @Setter
+@NoArgsConstructor
+@SuperBuilder
+public class GalaxyFilter extends SpaceEntityFilter {}

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/SpaceEntityFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/SpaceEntityFilter.java
@@ -1,0 +1,14 @@
+package com.example.universe.simulator.entityservice.filters;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter @Setter
+@NoArgsConstructor
+@SuperBuilder
+public class SpaceEntityFilter {
+
+    private String name;
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/SpaceEntityFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/SpaceEntityFilter.java
@@ -8,7 +8,7 @@ import lombok.experimental.SuperBuilder;
 @Getter @Setter
 @NoArgsConstructor
 @SuperBuilder
-public class SpaceEntityFilter {
+public abstract class SpaceEntityFilter {
 
     private String name;
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/repositories/GalaxyRepository.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/repositories/GalaxyRepository.java
@@ -2,10 +2,11 @@ package com.example.universe.simulator.entityservice.repositories;
 
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.UUID;
 
-public interface GalaxyRepository extends JpaRepository<Galaxy, UUID> {
+public interface GalaxyRepository extends JpaRepository<Galaxy, UUID>, JpaSpecificationExecutor<Galaxy> {
 
     boolean existsByName(String name);
 

--- a/src/main/java/com/example/universe/simulator/entityservice/services/GalaxyService.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/services/GalaxyService.java
@@ -8,6 +8,7 @@ import com.example.universe.simulator.entityservice.repositories.StarRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,12 +21,13 @@ public class GalaxyService {
     private final GalaxyRepository repository;
     private final StarRepository starRepository;
 
-    public Page<Galaxy> getList(Pageable pageable) {
-        return repository.findAll(pageable);
+    public Page<Galaxy> getList(Specification<Galaxy> specification, Pageable pageable) {
+        return repository.findAll(specification, pageable);
     }
 
     public Galaxy get(UUID id) throws AppException {
-        return repository.findById(id).orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
+        return repository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
     }
 
     @Transactional

--- a/src/main/java/com/example/universe/simulator/entityservice/services/MoonService.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/services/MoonService.java
@@ -25,7 +25,8 @@ public class MoonService {
     }
 
     public Moon get(UUID id) throws AppException {
-        return repository.findById(id).orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
+        return repository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
     }
 
     @Transactional

--- a/src/main/java/com/example/universe/simulator/entityservice/services/PlanetService.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/services/PlanetService.java
@@ -27,7 +27,8 @@ public class PlanetService {
     }
 
     public Planet get(UUID id) throws AppException {
-        return repository.findById(id).orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
+        return repository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
     }
 
     @Transactional

--- a/src/main/java/com/example/universe/simulator/entityservice/services/StarService.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/services/StarService.java
@@ -27,7 +27,8 @@ public class StarService {
     }
 
     public Star get(UUID id) throws AppException {
-        return repository.findById(id).orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
+        return repository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCodeType.NOT_FOUND_ENTITY));
     }
 
     @Transactional

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/AbstractSpecification.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/AbstractSpecification.java
@@ -1,0 +1,14 @@
+package com.example.universe.simulator.entityservice.specifications;
+
+import org.springframework.data.jpa.domain.Specification;
+
+abstract class AbstractSpecification<T> {
+
+    Specification<T> like(String property, String value) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.like(
+                        criteriaBuilder.lower(root.get(property)),
+                        "%" + value.toLowerCase() + "%"
+                );
+    }
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/AbstractSpecification.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/AbstractSpecification.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 abstract class AbstractSpecification<T> {
 
-    Specification<T> like(String property, String value) {
+    final Specification<T> like(String property, String value) {
         return (root, query, criteriaBuilder) ->
                 criteriaBuilder.like(
                         criteriaBuilder.lower(root.get(property)),

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/GalaxySpecification.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/GalaxySpecification.java
@@ -1,0 +1,13 @@
+package com.example.universe.simulator.entityservice.specifications;
+
+import com.example.universe.simulator.entityservice.entities.Galaxy;
+import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
+import org.springframework.data.jpa.domain.Specification;
+
+public class GalaxySpecification extends SpaceEntitySpecification<Galaxy, GalaxyFilter> {
+
+    @Override
+    Specification<Galaxy> getEntitySpecification(GalaxyFilter filter) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/SpaceEntitySpecification.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/SpaceEntitySpecification.java
@@ -1,0 +1,26 @@
+package com.example.universe.simulator.entityservice.specifications;
+
+import com.example.universe.simulator.entityservice.entities.SpaceEntity_;
+import com.example.universe.simulator.entityservice.filters.SpaceEntityFilter;
+import com.example.universe.simulator.entityservice.utils.Utils;
+import org.springframework.data.jpa.domain.Specification;
+
+abstract class SpaceEntitySpecification<ENTITY, FILTER extends SpaceEntityFilter> extends AbstractSpecification<ENTITY> {
+
+    public Specification<ENTITY> getSpecification(FILTER filter) {
+        return getCommonSpecification(filter)
+                .and(getEntitySpecification(filter));
+    }
+
+    private Specification<ENTITY> getCommonSpecification(FILTER filter) {
+        return Specification.where(nameLike(filter.getName()));
+    }
+
+    private Specification<ENTITY> nameLike(String name) {
+        return !Utils.isNullOrBlank(name)
+                ? like(SpaceEntity_.NAME, name)
+                : null;
+    }
+
+    abstract Specification<ENTITY> getEntitySpecification(FILTER filter);
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/SpaceEntitySpecification.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/SpaceEntitySpecification.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 abstract class SpaceEntitySpecification<ENTITY, FILTER extends SpaceEntityFilter> extends AbstractSpecification<ENTITY> {
 
-    public Specification<ENTITY> getSpecification(FILTER filter) {
+    public final Specification<ENTITY> getSpecification(FILTER filter) {
         return getCommonSpecification(filter)
                 .and(getEntitySpecification(filter));
     }

--- a/src/main/java/com/example/universe/simulator/entityservice/utils/Utils.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/utils/Utils.java
@@ -1,10 +1,12 @@
 package com.example.universe.simulator.entityservice.utils;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import java.util.Objects;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Utils {
-
-    private Utils() {}
 
     public static boolean isNullOrBlank(String str) {
         return Objects.isNull(str) || str.isBlank();

--- a/src/test/java/com/example/universe/simulator/entityservice/AbstractMockMvcTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/AbstractMockMvcTest.java
@@ -20,11 +20,11 @@ public abstract class AbstractMockMvcTest {
     @Autowired
     protected ObjectMapper objectMapper;
 
-    protected void verifyOkStatus(int status) {
+    protected final void verifyOkStatus(int status) {
         assertThat(status).isEqualTo(HttpStatus.OK.value());
     }
 
-    protected void verifyErrorResponse(String responseContent, ErrorCodeType errorCode) throws JsonProcessingException {
+    protected final void verifyErrorResponse(String responseContent, ErrorCodeType errorCode) throws JsonProcessingException {
         RestErrorResponse restErrorResponse = objectMapper.readValue(responseContent, RestErrorResponse.class);
 
         assertThat(restErrorResponse.getError()).isEqualTo(errorCode);

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
@@ -2,6 +2,7 @@ package com.example.universe.simulator.entityservice.integration;
 
 import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
+import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
 import com.example.universe.simulator.entityservice.utils.JsonPage;
 import com.example.universe.simulator.entityservice.utils.TestUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -22,7 +23,7 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         //-----------------------------------should throw sort parameter error-----------------------------------
 
         //when
-        MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get-list")
+        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/get-list")
                 .param("sort", "invalid")
         ).andReturn().getResponse();
         //then
@@ -31,7 +32,7 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         //-----------------------------------should return empty list-----------------------------------
 
         //when
-        response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
+        response = mockMvc.perform(post("/galaxy/get-list")).andReturn().getResponse();
         //then
         JsonPage<GalaxyDto> resultList = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
         assertThat(resultList.getContent()).isEmpty();
@@ -65,7 +66,7 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         //-----------------------------------should return list with 2 elements-----------------------------------
 
         //when
-        response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
+        response = mockMvc.perform(post("/galaxy/get-list")).andReturn().getResponse();
         //then
         resultList = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
         assertThat(resultList.getContent()).hasSize(2);
@@ -92,8 +93,8 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         ).andReturn().getResponse();
         //then
         GalaxyDto updatedDto = objectMapper.readValue(response.getContentAsString(), GalaxyDto.class);
-        assertThat(updatedDto.getName()).isEqualTo("name1Update");
-        assertThat(updatedDto.getVersion()).isEqualTo(1);
+        assertThat(updatedDto.getName()).isEqualTo(dto.getName());
+        assertThat(updatedDto.getVersion()).isEqualTo(dto.getVersion() + 1);
 
         //-----------------------------------should throw entity modified error-----------------------------------
 
@@ -107,6 +108,19 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         ).andReturn().getResponse();
         //then
         verifyErrorResponse(response.getContentAsString(), ErrorCodeType.ENTITY_MODIFIED);
+
+        //-----------------------------------should return list with 1 element-----------------------------------
+
+        //given
+        GalaxyFilter filter = GalaxyFilter.builder().name("1uP").build();
+        //when
+        response = mockMvc.perform(post("/galaxy/get-list")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(filter))
+        ).andReturn().getResponse();
+        //then
+        resultList = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
+        assertThat(resultList.getContent()).hasSize(1);
 
         //-----------------------------------should delete entity-----------------------------------
 
@@ -132,7 +146,7 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         //-----------------------------------should return empty list-----------------------------------
 
         //when
-        response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
+        response = mockMvc.perform(post("/galaxy/get-list")).andReturn().getResponse();
         //then
         resultList = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
         assertThat(resultList.getContent()).isEmpty();

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/MoonIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/MoonIntegrationTest.java
@@ -137,8 +137,8 @@ class MoonIntegrationTest extends AbstractIntegrationTest {
         ).andReturn().getResponse();
         //then
         MoonDto updatedDto = objectMapper.readValue(response.getContentAsString(), MoonDto.class);
-        assertThat(updatedDto.getName()).isEqualTo("name1Update");
-        assertThat(updatedDto.getVersion()).isEqualTo(1);
+        assertThat(updatedDto.getName()).isEqualTo(dto.getName());
+        assertThat(updatedDto.getVersion()).isEqualTo(dto.getVersion() + 1);
 
         //-----------------------------------should throw entity modified error-----------------------------------
 

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/StarIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/StarIntegrationTest.java
@@ -109,8 +109,8 @@ class StarIntegrationTest extends AbstractIntegrationTest {
         ).andReturn().getResponse();
         //then
         StarDto updatedDto = objectMapper.readValue(response.getContentAsString(), StarDto.class);
-        assertThat(updatedDto.getName()).isEqualTo("name1Update");
-        assertThat(updatedDto.getVersion()).isEqualTo(1);
+        assertThat(updatedDto.getName()).isEqualTo(dto.getName());
+        assertThat(updatedDto.getVersion()).isEqualTo(dto.getVersion() + 1);
 
         //-----------------------------------should throw entity modified error-----------------------------------
 

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/AbstractWebMvcTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/AbstractWebMvcTest.java
@@ -18,7 +18,7 @@ public abstract class AbstractWebMvcTest extends AbstractMockMvcTest {
     @Autowired
     protected ModelMapper modelMapper;
 
-    protected void verifySuccessfulResponse(MockHttpServletResponse response, Object expected) throws JsonProcessingException, UnsupportedEncodingException {
+    protected final void verifySuccessfulResponse(MockHttpServletResponse response, Object expected) throws JsonProcessingException, UnsupportedEncodingException {
         verifyOkStatus(response.getStatus());
         assertThat(response.getContentAsString()).isEqualTo(objectMapper.writeValueAsString(expected));
     }

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/CommonControllerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/CommonControllerTest.java
@@ -5,14 +5,13 @@ import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
 import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
+import com.example.universe.simulator.entityservice.utils.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.List;
@@ -20,7 +19,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 /**
  * Common controller cases are tested using GalaxyController.
@@ -38,15 +37,15 @@ class CommonControllerTest extends AbstractWebMvcTest {
                 Galaxy.builder().name("name").build()
         );
 
-        Pageable pageable = PageRequest.of(0, 20, Sort.unsorted());
+        Pageable pageable = TestUtils.getDefaultPageable();
         Page<Galaxy> entityPage = new PageImpl<>(entityList, pageable, entityList.size());
         Page<GalaxyDto> dtoPage = entityPage.map(item -> modelMapper.map(item, GalaxyDto.class));
 
-        given(service.getList(any())).willReturn(entityPage);
+        given(service.getList(any(), any())).willReturn(entityPage);
         //when
-        MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get-list")).andReturn().getResponse();
+        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/get-list")).andReturn().getResponse();
         //then
         verifySuccessfulResponse(response, dtoPage);
-        then(service).should().getList(pageable);
+        then(service).should().getList(null, pageable);
     }
 }

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/GalaxyControllerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/GalaxyControllerTest.java
@@ -51,9 +51,9 @@ class GalaxyControllerTest extends AbstractWebMvcTest {
         Page<Galaxy> entityPage = new PageImpl<>(entityList, pageable, entityList.size());
         Page<GalaxyDto> dtoPage = entityPage.map(item -> modelMapper.map(item, GalaxyDto.class));
 
-        given(service.getList(any())).willReturn(entityPage);
+        given(service.getList(any(), any())).willReturn(entityPage);
         //when
-        MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get-list")
+        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/get-list")
                 .param("page", "1")
                 .param("size", "2")
                 .param("sort", "version,desc")
@@ -61,7 +61,7 @@ class GalaxyControllerTest extends AbstractWebMvcTest {
         ).andReturn().getResponse();
         //then
         verifySuccessfulResponse(response, dtoPage);
-        then(service).should().getList(pageable);
+        then(service).should().getList(null, pageable);
     }
 
     @Test

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
@@ -130,15 +130,17 @@ class RestExceptionHandlerTest extends AbstractWebMvcTest {
     void testPropertyReferenceException() throws Exception {
         //given
         Sort sort = Sort.by(Sort.Order.asc("invalid"));
-        Pageable pageable = PageRequest.of(0, 20, sort);
-        given(service.getList(any())).willThrow(PropertyReferenceException.class);
+        Pageable defaultPageable = TestUtils.getDefaultPageable();
+        Pageable pageable = PageRequest.of(defaultPageable.getPageNumber(), defaultPageable.getPageSize(), sort);
+
+        given(service.getList(any(), any())).willThrow(PropertyReferenceException.class);
         //when
-        MockHttpServletResponse response = mockMvc.perform(get("/galaxy/get-list")
+        MockHttpServletResponse response = mockMvc.perform(post("/galaxy/get-list")
                 .param("sort", "invalid")
         ).andReturn().getResponse();
         //then
         verifyErrorResponse(response.getContentAsString(), ErrorCodeType.INVALID_SORT_PARAMETER);
-        then(service).should().getList(pageable);
+        then(service).should().getList(null, pageable);
     }
 
     @Test

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/GalaxyServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/GalaxyServiceTest.java
@@ -3,17 +3,21 @@ package com.example.universe.simulator.entityservice.unit.services;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.exception.ErrorCodeType;
+import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
 import com.example.universe.simulator.entityservice.repositories.GalaxyRepository;
 import com.example.universe.simulator.entityservice.repositories.StarRepository;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
+import com.example.universe.simulator.entityservice.specifications.GalaxySpecification;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,16 +49,19 @@ class GalaxyServiceTest {
         List<Galaxy> list = List.of(
                 Galaxy.builder().name("name").build()
         );
-
         Pageable pageable = Pageable.unpaged();
         Page<Galaxy> page = new PageImpl<>(list, pageable, list.size());
 
-        given(repository.findAll(any(Pageable.class))).willReturn(page);
+        Optional<GalaxyFilter> filter = Optional.of(GalaxyFilter.builder().name("name").build());
+        Specification<Galaxy> specification = new GalaxySpecification().getSpecification(filter.get());
+
+        given(repository.findAll(ArgumentMatchers.<Specification<Galaxy>>any(), any(Pageable.class)))
+                .willReturn(page);
         //when
-        Page<Galaxy> result = service.getList(pageable);
+        Page<Galaxy> result = service.getList(specification, pageable);
         //then
         assertThat(result).isEqualTo(page);
-        then(repository).should().findAll(pageable);
+        then(repository).should().findAll(specification, pageable);
     }
 
     @Test

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/MoonServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/MoonServiceTest.java
@@ -46,7 +46,6 @@ class MoonServiceTest {
         List<Moon> list = List.of(
                 Moon.builder().name("name").build()
         );
-
         Pageable pageable = Pageable.unpaged();
         Page<Moon> page = new PageImpl<>(list, pageable, list.size());
 

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/PlanetServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/PlanetServiceTest.java
@@ -50,10 +50,9 @@ class PlanetServiceTest {
         List<Planet> list = List.of(
                 Planet.builder().name("name").build()
         );
-        
         Pageable pageable = Pageable.unpaged();
         Page<Planet> page = new PageImpl<>(list, pageable, list.size());
-        
+
         given(repository.findAll(any(Pageable.class))).willReturn(page);
         //when
         Page<Planet> result = service.getList(pageable);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/StarServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/StarServiceTest.java
@@ -50,7 +50,6 @@ class StarServiceTest {
         List<Star> list = List.of(
                 Star.builder().name("name").build()
         );
-
         Pageable pageable = Pageable.unpaged();
         Page<Star> page = new PageImpl<>(list, pageable, list.size());
 

--- a/src/test/java/com/example/universe/simulator/entityservice/utils/TestUtils.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/utils/TestUtils.java
@@ -4,12 +4,19 @@ import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.dtos.MoonDto;
 import com.example.universe.simulator.entityservice.dtos.PlanetDto;
 import com.example.universe.simulator.entityservice.dtos.StarDto;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.UUID;
 
 public final class TestUtils {
 
     private TestUtils() {}
+
+    public static Pageable getDefaultPageable() {
+        return PageRequest.of(0, 20, Sort.unsorted());
+    }
 
     public static GalaxyDto buildGalaxyDtoForAdd() {
         return GalaxyDto.builder()
@@ -51,7 +58,7 @@ public final class TestUtils {
         PlanetDto result = buildPlanetDtoForAdd();
         result.setId(UUID.randomUUID());
         result.setVersion(0L);
-        
+
         return result;
     }
 


### PR DESCRIPTION
- added hibernate-jpamodelgen dependency
- added src/main/generated entry in .gitignore
- added SpaceEntityFilter and GalaxyFilter
- added AbstractSpecification, SpaceEntitySpecification and GalaxySpecification
- GalaxyRepository now extends JpaSpecificationExecutor
- added specification argument to getList method in GalaxyService
- changed getList method type to POST in GalaxyController
- added optional filter argument to getList method in GalaxyController
- improved readability of get method in all services
- renamed validateDtoSpecificFields and fixDtoSpecificDirtyFields methods and made them package-private in SpaceEntityDto
- added final modifier to methods in various abstract classes
- added getDefaultPageable method in TestUtils
- replaced hardcoded values when testing update method in integration tests
- replaced default private constructor with lombok annotation in Utils