### PR TITLE
updated springdoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ bootBuildImage {
 }
 
 ext {
-    set('springdocOpenapiVersion', '1.5.3')
+    set('springdocOpenapiVersion', '1.5.4')
 }
 
 repositories {

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -21,3 +21,5 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
 #logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-6level)[%thread] [%logger] :: %msg%n
+#springdoc
+springdoc.swagger-ui.tagsSorter=alpha


### PR DESCRIPTION
- updated springdoc-openapi to 1.5.4
- controllers are now sorted alphanumerically in swagger ui