### PR TITLE
enabled TLS in vault

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
           "listener": {
             "tcp": {
               "address": "0.0.0.0:8200",
-              "tls_disable": true
+              "tls_cert_file": "/vault/universe-simulator-cert.pem",
+              "tls_key_file": "/vault/universe-simulator-key.pem"
             }
           },
           "ui": true
@@ -27,6 +28,8 @@ services:
     volumes:
       - vault-logs:/vault/logs
       - vault-file:/vault/file
+      - ~/universe-simulator/universe-simulator-cert.pem:/vault/universe-simulator-cert.pem:ro
+      - ~/universe-simulator/universe-simulator-key.pem:/vault/universe-simulator-key.pem:ro
 
   rabbitmq:
     image: rabbitmq:management

--- a/docs/project-description.adoc
+++ b/docs/project-description.adoc
@@ -8,8 +8,7 @@ The project is built with `Java 11`.
 the `gradle/wrapper/gradle-wrapper.properties` file.
 
 === Updating
-You can update gradle wrapper with the following command:
-`./gradlew wrapper --gradle-version=x.x.x --distribution-type=all
+You can update gradle wrapper with: `./gradlew wrapper --gradle-version=x.x.x --distribution-type=all
 --gradle-distribution-sha256-sum=some-checksome`. Valid gradle distribution checksomes can be found
 at gradle's https://gradle.org/release-checksums/[Checksome reference page].
 
@@ -28,8 +27,8 @@ are excluded from git.
 `JaCoCo` plugin is used to analyze code coverage.
 
 === Report
-You can generate the test coverage report with the following command: `./gradlew jacocoTestReport`.
-The report can be viewed by opening the `build/reports/jacoco/test/html/index.html` file.
+You can generate the test coverage report with: `./gradlew jacocoTestReport`. The report can be
+viewed by opening the `build/reports/jacoco/test/html/index.html` file.
 
 === Exclusions
 Classes which are excluded from jacoco reports are described in the `jacocoExclusions` method in
@@ -40,8 +39,8 @@ automatically excludes such code from processing.
 
 === Rules
 100% code coverage is enforced by the `jacocoTestCoverageVerification` task. You can run this task
-with the following command: `./gradlew jacocoTestCoverageVerification`. If the coverage falls below
-100%, the task will fail.
+with: `./gradlew jacocoTestCoverageVerification`. If the coverage falls below 100%, the task will
+fail.
 
 == CI/CD
 `Github Actions` is used for automating the project workflow. The workflow file can be found in the

--- a/docs/project-setup.adoc
+++ b/docs/project-setup.adoc
@@ -1,33 +1,58 @@
 = Project setup
 
-== Software
-Run `docker-compose -p universe-simulator up -d` to install all required software (`vault, rabbitmq,
-postgres`).
-
 == Https/TLS
-You need to have a keystore file named `universe-simulator.p12` in your `${HOME}/universe-simulator`
-directory. The certificate in the keystore can be either self-signed or provided by a CA.
+You need to have the following files in your `${HOME}/universe-simulator` directory:
+
+* a keystore file named `universe-simulator.p12`
+* a certificate file named `universe-simulator-cert.pem`
+* a private key file named `universe-simulator-key.pem`
 
 === Keystore
-You can use java's `keytool` utility for working with keystore. To create a keystore file with a
-self-signed certificate, run the following command: `keytool -genkeypair -alias universe-simulator
--keyalg RSA -validity 365 -keystore universe-simulator.p12` and follow the instructions.
+The certificate in the keystore can be either self-signed or provided by a CA. You can use
+`openssql` and java's `keytool` utility for working with keystore. To create all the necessary files,
+follow these steps:
+
+* Create a keystore with a self-signed certificate and a private key: `keytool -genkeypair -v
+-alias universe-simulator -keystore universe-simulator.p12 -keyalg RSA -validity 365
+-ext SAN=dns:localhost,ip:127.0.0.1`
+
+* Extract the certificate from the keystore with:
+`openssl pkcs12 -in universe-simulator.p12 -out universe-simulator-cert.pem -nokeys`
+
+* Extract the private key from the keystore with:
+`openssl pkcs12 -in universe-simulator.p12 -out universe-simulator-key.pem -nodes -nocerts`
 
 == Vault
 * When vault is up and running, go to vault ui at `localhost:8200` and follow the setup instructions.
+
 * After the setup, log in and enable a new `KV` engine with `universe-simulator` as path. This root
 path maps to the `spring.cloud.vault.kv.backend` property in `bootstrap.properties`.
+
 * In the `universe-simulator` engine create a secret with `entity-service/local` as path.
 `entity-service` maps to the `spring.application.name` property in `bootstrap.properties` and `local`
 maps to your spring boot profile used for local development. Similarly, you can add as many
 profile-specific paths as needed (e.g. `entity-service/staging, entity-service/prod`).
+
 * Add all required properties from the `bootstrap.properties` file to the
 `universe-simulator/entity-service/local` path. You can identify such properties by the kebab-case
 syntax (e.g. `${server-port}`).
 
+* Go to `Policies` and edit the `default` policy by adding capabilities for the
+`universe-simulator/pass:[*]` path, similar to the `cubbyhole/pass:[*]` path. Example:
++
+----
+path "universe-simulator/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+}
+----
+
+* Go to `Access > Auth Methods` and add a new `TLS Certificates` auth method. Use the default `cert`
+path.
+
+* Add your `universe-simulator-cert.pem` certificate to the created auth method.
+
 == Environment variables
-Add the following OS environment variables: `US_VAULT_HOST, US_VAULT_PORT, US_VAULT_TOKEN`. These are
-needed for the vault connection.
+Add the following OS environment variables: `US_VAULT_HOST, US_VAULT_PORT, US_KEYSTORE_PASSWORD`.
 
 == Properties file
 Add `bootstrap-local.properties` file and if needed, override any properties from the

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -1,17 +1,20 @@
 spring.application.name=entity-service
 #vault
 spring.cloud.vault.fail-fast=true
-spring.cloud.vault.scheme=http
 spring.cloud.vault.host=${US_VAULT_HOST}
 spring.cloud.vault.port=${US_VAULT_PORT}
-spring.cloud.vault.token=${US_VAULT_TOKEN}
 spring.cloud.vault.kv.backend=universe-simulator
+spring.cloud.vault.authentication=cert
+spring.cloud.vault.ssl.trust-store=file:${server.ssl.key-store}
+spring.cloud.vault.ssl.trust-store-password=${US_KEYSTORE_PASSWORD}
+spring.cloud.vault.ssl.key-store=file:${server.ssl.key-store}
+spring.cloud.vault.ssl.key-store-password=${US_KEYSTORE_PASSWORD}
 #server
 server.shutdown=graceful
 server.port=${server-port}
 server.http2.enabled=true
 server.ssl.key-store=${HOME}/universe-simulator/universe-simulator.p12
-server.ssl.key-store-password=${keystore-password}
+server.ssl.key-store-password=${US_KEYSTORE_PASSWORD}
 #logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [${spring.application.name},%X{traceId},%X{spanId}] [%thread] [%logger] :: %msg%n
 #datasource


### PR DESCRIPTION
- added tls config in vault service in docker-compose.yml
- removed spring.cloud.vault.scheme property in bootstrap.properties (it's https by default)
- changed vault authentication mode (spring.cloud.vault.authentication property) to cert in bootstrap.properties
- removed spring.cloud.vault.token property in bootstrap.properties
- added vault ssl properties in bootstrap.properties
- server.ssl.key-store-password property value in bootstrap.properties is now read from US_KEYSTORE_PASSWORD env variable
- moved Software section after Https/TLS section in project-setup.adoc
- edited Https/TLS section in project-setup.adoc
- edited Vault section in project-setup.adoc
- edited Environment variables section in project-setup.adoc
- simplified instructions when using commands in project-description.adoc