### PR TITLE
updated springdoc-openapi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ repositories {
 }
 
 ext {
-    set('springdocOpenapiVersion', '1.5.7')
+    set('springdocOpenapiVersion', '1.5.8')
 }
 
 dependencyManagement {

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -36,6 +36,7 @@ spring.rabbitmq.port=${rabbitmq-port}
 spring.rabbitmq.username=${rabbitmq-username}
 spring.rabbitmq.password=${rabbitmq-password}
 #springdoc
-springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
 #zipkin
 spring.zipkin.base-url=http://${zipkin-host}:${zipkin-port}


### PR DESCRIPTION
- updated springdoc-openapi to 1.5.8
- fixed springdoc.swagger-ui.tags-sorter property name in bootstrap.properties
- added springdoc.swagger-ui.operations-sorter property in bootstrap.properties