### PR TITLE
added rabbit tls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.modelmapper:modelmapper:2.4.1'
     implementation "org.springdoc:springdoc-openapi-data-rest:${springdocOpenapiVersion}"
+    runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-amqp'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'org.springframework.cloud:spring-cloud-starter-bootstrap'

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - docker-env-file
     volumes:
-      - ~/universe-simulator/universe-simulator.p12:/home/cnb/universe-simulator/universe-simulator.p12:ro
+      - ~/universe-simulator/universe-simulator.p12:/home/cnb/universe-simulator/universe-simulator.p12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
     volumes:
       - vault-logs:/vault/logs
       - vault-file:/vault/file
-      - ~/universe-simulator/universe-simulator-cert.pem:/vault/universe-simulator-cert.pem:ro
-      - ~/universe-simulator/universe-simulator-key.pem:/vault/universe-simulator-key.pem:ro
+      - ~/universe-simulator/universe-simulator-cert.pem:/vault/universe-simulator-cert.pem
+      - ~/universe-simulator/universe-simulator-key.pem:/vault/universe-simulator-key.pem
 
   zipkin:
     image: openzipkin/zipkin
@@ -45,11 +45,17 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=username
       - RABBITMQ_DEFAULT_PASS=password
+      - RABBITMQ_SSL_CACERTFILE=/var/lib/rabbitmq/universe-simulator-cert.pem
+      - RABBITMQ_SSL_CERTFILE=/var/lib/rabbitmq/universe-simulator-cert.pem
+      - RABBITMQ_SSL_KEYFILE=/var/lib/rabbitmq/universe-simulator-key.pem
+      - RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT=false
     ports:
-      - 5672:5672
-      - 15672:15672
+      - 5671:5671
+      - 15671:15671
     volumes:
       - rabbitmq:/var/lib/rabbitmq
+      - ~/universe-simulator/universe-simulator-cert.pem:/var/lib/rabbitmq/universe-simulator-cert.pem
+      - ~/universe-simulator/universe-simulator-key.pem:/var/lib/rabbitmq/universe-simulator-key.pem
 
   entity-service-postgres:
     image: postgres

--- a/docs/project-setup.adoc
+++ b/docs/project-setup.adoc
@@ -14,7 +14,7 @@ follow these steps:
 
 * Create a keystore with a self-signed certificate and a private key: `keytool -genkeypair -v
 -alias universe-simulator -keystore universe-simulator.p12 -keyalg RSA -validity 365
--ext SAN=dns:localhost,ip:127.0.0.1`
+-ext SAN=dns:localhost,ip:127.0.0.1`. Make sure to enter some valid country code when prompted.
 
 * Extract the certificate from the keystore with:
 `openssl pkcs12 -in universe-simulator.p12 -out universe-simulator-cert.pem -nokeys`

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -5,15 +5,15 @@ spring.cloud.vault.host=${US_VAULT_HOST}
 spring.cloud.vault.port=${US_VAULT_PORT}
 spring.cloud.vault.kv.backend=universe-simulator
 spring.cloud.vault.authentication=cert
-spring.cloud.vault.ssl.trust-store=file:${server.ssl.key-store}
+spring.cloud.vault.ssl.trust-store=${server.ssl.key-store}
 spring.cloud.vault.ssl.trust-store-password=${US_KEYSTORE_PASSWORD}
-spring.cloud.vault.ssl.key-store=file:${server.ssl.key-store}
+spring.cloud.vault.ssl.key-store=${server.ssl.key-store}
 spring.cloud.vault.ssl.key-store-password=${US_KEYSTORE_PASSWORD}
 #server
 server.shutdown=graceful
 server.port=${server-port}
 server.http2.enabled=true
-server.ssl.key-store=${HOME}/universe-simulator/universe-simulator.p12
+server.ssl.key-store=file:${HOME}/universe-simulator/universe-simulator.p12
 server.ssl.key-store-password=${US_KEYSTORE_PASSWORD}
 #logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [${spring.application.name},%X{traceId},%X{spanId}] [%thread] [%logger] :: %msg%n
@@ -35,6 +35,9 @@ spring.rabbitmq.host=${rabbitmq-host}
 spring.rabbitmq.port=${rabbitmq-port}
 spring.rabbitmq.username=${rabbitmq-username}
 spring.rabbitmq.password=${rabbitmq-password}
+spring.rabbitmq.ssl.enabled=true
+spring.rabbitmq.ssl.trust-store=${server.ssl.key-store}
+spring.rabbitmq.ssl.trust-store-password=${US_KEYSTORE_PASSWORD}
 #springdoc
 springdoc.swagger-ui.tags-sorter=alpha
 springdoc.swagger-ui.operations-sorter=alpha


### PR DESCRIPTION
- added tls config for rabbitmq service in docker-compose.yml
- added ssl properties in rabbitmq section in bootstrap.properties
- added note to specify valid country code when creating certificates in project-setup.adoc
- added spring-boot-starter-actuator dependency
- added file: prefix to server.ssl.key-store property in bootstrap.properties
- removed readonly access from cert volumes in vault service in docker-compose.yml
- removed readonly access from cert volume in entity-service-app service in deployment/docker-compose.yml