### PR TITLE
reworked specifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,4 +117,6 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.testcontainers:rabbitmq'
     testRuntimeOnly 'com.h2database:h2'
+    // adds ability to mock/verify final methods
+    testRuntimeOnly 'org.mockito:mockito-inline'
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/GalaxyController.java
@@ -5,7 +5,7 @@ import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
-import com.example.universe.simulator.entityservice.specifications.GalaxySpecification;
+import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.GalaxyDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,15 +35,13 @@ public class GalaxyController {
 
     private final GalaxyService service;
     private final GalaxyDtoValidator validator;
+    private final GalaxySpecificationBuilder specificationBuilder;
     private final ModelMapper modelMapper;
 
     @PostMapping("get-list")
     public Callable<Page<GalaxyDto>> getList(@RequestBody Optional<GalaxyFilter> filter, @ParameterObject Pageable pageable) {
         log.info("calling getList with filter [{}] and {}", filter.orElse(null), pageable);
-
-        Specification<Galaxy> specification = filter
-            .map(item -> new GalaxySpecification().getSpecification(item))
-            .orElse(null);
+        Specification<Galaxy> specification = specificationBuilder.build(filter.orElse(null));
 
         return () -> {
             Page<GalaxyDto> result = service.getList(specification, pageable)

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/MoonController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/MoonController.java
@@ -5,7 +5,7 @@ import com.example.universe.simulator.entityservice.entities.Moon;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.MoonFilter;
 import com.example.universe.simulator.entityservice.services.MoonService;
-import com.example.universe.simulator.entityservice.specifications.MoonSpecification;
+import com.example.universe.simulator.entityservice.specifications.MoonSpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.MoonDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,15 +35,13 @@ public class MoonController {
 
     private final MoonService service;
     private final MoonDtoValidator validator;
+    private final MoonSpecificationBuilder specificationBuilder;
     private final ModelMapper modelMapper;
 
     @PostMapping("get-list")
     public Callable<Page<MoonDto>> getList(@RequestBody Optional<MoonFilter> filter, @ParameterObject Pageable pageable) {
         log.info("calling getList with filter [{}] and {}", filter.orElse(null), pageable);
-
-        Specification<Moon> specification = filter
-            .map(item -> new MoonSpecification().getSpecification(item))
-            .orElse(null);
+        Specification<Moon> specification = specificationBuilder.build(filter.orElse(null));
 
         return () -> {
             Page<MoonDto> result = service.getList(specification, pageable)

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/PlanetController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/PlanetController.java
@@ -5,7 +5,7 @@ import com.example.universe.simulator.entityservice.entities.Planet;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.PlanetFilter;
 import com.example.universe.simulator.entityservice.services.PlanetService;
-import com.example.universe.simulator.entityservice.specifications.PlanetSpecification;
+import com.example.universe.simulator.entityservice.specifications.PlanetSpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.PlanetDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,15 +35,13 @@ public class PlanetController {
 
     private final PlanetService service;
     private final PlanetDtoValidator validator;
+    private final PlanetSpecificationBuilder specificationBuilder;
     private final ModelMapper modelMapper;
 
     @PostMapping("get-list")
     public Callable<Page<PlanetDto>> getList(@RequestBody Optional<PlanetFilter> filter, @ParameterObject Pageable pageable) {
         log.info("calling getList with filter [{}] and {}", filter.orElse(null), pageable);
-
-        Specification<Planet> specification = filter
-            .map(item -> new PlanetSpecification().getSpecification(item))
-            .orElse(null);
+        Specification<Planet> specification = specificationBuilder.build(filter.orElse(null));
 
         return () -> {
             Page<PlanetDto> result = service.getList(specification, pageable)

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/StarController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/StarController.java
@@ -5,7 +5,7 @@ import com.example.universe.simulator.entityservice.entities.Star;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.StarFilter;
 import com.example.universe.simulator.entityservice.services.StarService;
-import com.example.universe.simulator.entityservice.specifications.StarSpecification;
+import com.example.universe.simulator.entityservice.specifications.StarSpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.StarDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,15 +35,13 @@ public class StarController {
 
     private final StarService service;
     private final StarDtoValidator validator;
+    private final StarSpecificationBuilder specificationBuilder;
     private final ModelMapper modelMapper;
 
     @PostMapping("get-list")
     public Callable<Page<StarDto>> getList(@RequestBody Optional<StarFilter> filter, @ParameterObject Pageable pageable) {
         log.info("calling getList with filter [{}] and {}", filter.orElse(null), pageable);
-
-        Specification<Star> specification = filter
-            .map(item -> new StarSpecification().getSpecification(item))
-            .orElse(null);
+        Specification<Star> specification = specificationBuilder.build(filter.orElse(null));
 
         return () -> {
             Page<StarDto> result = service.getList(specification, pageable)

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/GalaxyFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/GalaxyFilter.java
@@ -1,5 +1,6 @@
 package com.example.universe.simulator.entityservice.filters;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.experimental.SuperBuilder;
 @Getter @Setter
 @NoArgsConstructor
 @SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class GalaxyFilter extends SpaceEntityFilter {}

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/MoonFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/MoonFilter.java
@@ -1,5 +1,6 @@
 package com.example.universe.simulator.entityservice.filters;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.experimental.SuperBuilder;
 @Getter @Setter
 @NoArgsConstructor
 @SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class MoonFilter extends SpaceEntityFilter {}

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/PlanetFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/PlanetFilter.java
@@ -1,5 +1,6 @@
 package com.example.universe.simulator.entityservice.filters;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.experimental.SuperBuilder;
 @Getter @Setter
 @NoArgsConstructor
 @SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class PlanetFilter extends SpaceEntityFilter {}

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/SpaceEntityFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/SpaceEntityFilter.java
@@ -1,5 +1,6 @@
 package com.example.universe.simulator.entityservice.filters;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +10,7 @@ import lombok.experimental.SuperBuilder;
 @Getter @Setter
 @NoArgsConstructor
 @SuperBuilder
+@EqualsAndHashCode
 @ToString
 public abstract class SpaceEntityFilter {
 

--- a/src/main/java/com/example/universe/simulator/entityservice/filters/StarFilter.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/filters/StarFilter.java
@@ -1,5 +1,6 @@
 package com.example.universe.simulator.entityservice.filters;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.experimental.SuperBuilder;
 @Getter @Setter
 @NoArgsConstructor
 @SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class StarFilter extends SpaceEntityFilter {}

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/AbstractSpecifications.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/AbstractSpecifications.java
@@ -4,9 +4,9 @@ import lombok.experimental.UtilityClass;
 import org.springframework.data.jpa.domain.Specification;
 
 @UtilityClass
-class AbstractSpecification {
+public class AbstractSpecifications {
 
-    <T> Specification<T> like(String property, String value) {
+    public <T> Specification<T> like(String property, String value) {
         return (root, query, criteriaBuilder) ->
             criteriaBuilder.like(
                 criteriaBuilder.lower(root.get(property)),

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/GalaxySpecificationBuilder.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/GalaxySpecificationBuilder.java
@@ -3,11 +3,13 @@ package com.example.universe.simulator.entityservice.specifications;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
 
-public class GalaxySpecification extends SpaceEntitySpecification<Galaxy, GalaxyFilter> {
+@Component
+public class GalaxySpecificationBuilder extends SpaceEntitySpecificationBuilder<Galaxy, GalaxyFilter> {
 
     @Override
-    Specification<Galaxy> getEntitySpecification(GalaxyFilter filter) {
+    Specification<Galaxy> buildEntitySpecification(GalaxyFilter filter) {
         return null;
     }
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/MoonSpecificationBuilder.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/MoonSpecificationBuilder.java
@@ -3,11 +3,13 @@ package com.example.universe.simulator.entityservice.specifications;
 import com.example.universe.simulator.entityservice.entities.Moon;
 import com.example.universe.simulator.entityservice.filters.MoonFilter;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
 
-public class MoonSpecification extends SpaceEntitySpecification<Moon, MoonFilter> {
+@Component
+public class MoonSpecificationBuilder extends SpaceEntitySpecificationBuilder<Moon, MoonFilter> {
 
     @Override
-    Specification<Moon> getEntitySpecification(MoonFilter filter) {
+    Specification<Moon> buildEntitySpecification(MoonFilter filter) {
         return null;
     }
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/PlanetSpecificationBuilder.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/PlanetSpecificationBuilder.java
@@ -3,11 +3,13 @@ package com.example.universe.simulator.entityservice.specifications;
 import com.example.universe.simulator.entityservice.entities.Planet;
 import com.example.universe.simulator.entityservice.filters.PlanetFilter;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
 
-public class PlanetSpecification extends SpaceEntitySpecification<Planet, PlanetFilter> {
+@Component
+public class PlanetSpecificationBuilder extends SpaceEntitySpecificationBuilder<Planet, PlanetFilter> {
 
     @Override
-    Specification<Planet> getEntitySpecification(PlanetFilter filter) {
+    Specification<Planet> buildEntitySpecification(PlanetFilter filter) {
         return null;
     }
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/SpaceEntitySpecificationBuilder.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/SpaceEntitySpecificationBuilder.java
@@ -6,22 +6,26 @@ import com.example.universe.simulator.entityservice.filters.SpaceEntityFilter;
 import com.example.universe.simulator.entityservice.utils.Utils;
 import org.springframework.data.jpa.domain.Specification;
 
-abstract class SpaceEntitySpecification<E extends SpaceEntity, F extends SpaceEntityFilter> {
+import java.util.Objects;
 
-    public final Specification<E> getSpecification(F filter) {
-        return getCommonSpecification(filter)
-            .and(getEntitySpecification(filter));
+abstract class SpaceEntitySpecificationBuilder<E extends SpaceEntity, F extends SpaceEntityFilter> {
+
+    public final Specification<E> build(F filter) {
+        return Objects.nonNull(filter)
+            ? buildCommonSpecification(filter)
+            .and(buildEntitySpecification(filter))
+            : null;
     }
 
-    private Specification<E> getCommonSpecification(F filter) {
+    private Specification<E> buildCommonSpecification(F filter) {
         return Specification.where(nameLike(filter.getName()));
     }
 
     private Specification<E> nameLike(String name) {
         return !Utils.isNullOrBlank(name)
-            ? AbstractSpecification.like(SpaceEntity_.NAME, name)
+            ? AbstractSpecifications.like(SpaceEntity_.NAME, name)
             : null;
     }
 
-    abstract Specification<E> getEntitySpecification(F filter);
+    abstract Specification<E> buildEntitySpecification(F filter);
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/specifications/StarSpecificationBuilder.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/specifications/StarSpecificationBuilder.java
@@ -3,11 +3,13 @@ package com.example.universe.simulator.entityservice.specifications;
 import com.example.universe.simulator.entityservice.entities.Star;
 import com.example.universe.simulator.entityservice.filters.StarFilter;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
 
-public class StarSpecification extends SpaceEntitySpecification<Star, StarFilter> {
+@Component
+public class StarSpecificationBuilder extends SpaceEntitySpecificationBuilder<Star, StarFilter> {
 
     @Override
-    Specification<Star> getEntitySpecification(StarFilter filter) {
+    Specification<Star> buildEntitySpecification(StarFilter filter) {
         return null;
     }
 }

--- a/src/test/java/com/example/universe/simulator/entityservice/common/utils/TestUtils.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/common/utils/TestUtils.java
@@ -9,6 +9,10 @@ import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.entities.Moon;
 import com.example.universe.simulator.entityservice.entities.Planet;
 import com.example.universe.simulator.entityservice.entities.Star;
+import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
+import com.example.universe.simulator.entityservice.filters.MoonFilter;
+import com.example.universe.simulator.entityservice.filters.PlanetFilter;
+import com.example.universe.simulator.entityservice.filters.StarFilter;
 import com.example.universe.simulator.entityservice.types.EventType;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -53,6 +57,12 @@ public final class TestUtils {
         return result;
     }
 
+    public static GalaxyFilter buildGalaxyFilter() {
+        return GalaxyFilter.builder()
+            .name("name")
+            .build();
+    }
+
     public static Galaxy buildGalaxy() {
         return Galaxy.builder()
             .id(UUID.randomUUID())
@@ -73,6 +83,12 @@ public final class TestUtils {
         result.setVersion(0L);
 
         return result;
+    }
+
+    public static StarFilter buildStarFilter() {
+        return StarFilter.builder()
+            .name("name")
+            .build();
     }
 
     public static Star buildStar() {
@@ -98,6 +114,12 @@ public final class TestUtils {
         return result;
     }
 
+    public static PlanetFilter buildPlanetFilter() {
+        return PlanetFilter.builder()
+            .name("name")
+            .build();
+    }
+
     public static Planet buildPlanet() {
         return Planet.builder()
             .id(UUID.randomUUID())
@@ -119,6 +141,12 @@ public final class TestUtils {
         result.setVersion(0L);
 
         return result;
+    }
+
+    public static MoonFilter buildMoonFilter() {
+        return MoonFilter.builder()
+            .name("name")
+            .build();
     }
 
     public static Moon buildMoon() {

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
@@ -91,7 +91,8 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         // -----------------------------------should return list with 1 element-----------------------------------
 
         // given
-        GalaxyFilter filter = GalaxyFilter.builder().name("1uP").build();
+        GalaxyFilter filter = TestUtils.buildGalaxyFilter();
+        filter.setName("1uP");
         // when
         response = performRequest(post("/galaxy/get-list")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/MoonIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/MoonIntegrationTest.java
@@ -136,7 +136,8 @@ class MoonIntegrationTest extends AbstractIntegrationTest {
         // -----------------------------------should return list with 1 element-----------------------------------
 
         // given
-        MoonFilter filter = MoonFilter.builder().name("1uP").build();
+        MoonFilter filter = TestUtils.buildMoonFilter();
+        filter.setName("1uP");
         // when
         response = performRequest(post("/moon/get-list")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/PlanetIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/PlanetIntegrationTest.java
@@ -122,7 +122,8 @@ class PlanetIntegrationTest extends AbstractIntegrationTest {
         // -----------------------------------should return list with 1 element-----------------------------------
 
         // given
-        PlanetFilter filter = PlanetFilter.builder().name("1uP").build();
+        PlanetFilter filter = TestUtils.buildPlanetFilter();
+        filter.setName("1uP");
         // when
         response = performRequest(post("/planet/get-list")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/StarIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/StarIntegrationTest.java
@@ -108,7 +108,8 @@ class StarIntegrationTest extends AbstractIntegrationTest {
         // -----------------------------------should return list with 1 element-----------------------------------
 
         // given
-        StarFilter filter = StarFilter.builder().name("1uP").build();
+        StarFilter filter = TestUtils.buildStarFilter();
+        filter.setName("1uP");
         // when
         response = performRequest(post("/star/get-list")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
@@ -6,6 +6,7 @@ import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
+import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
 import com.example.universe.simulator.entityservice.types.ErrorCodeType;
 import com.example.universe.simulator.entityservice.unit.AbstractWebMvcTest;
 import com.example.universe.simulator.entityservice.validators.GalaxyDtoValidator;
@@ -41,10 +42,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 class RestExceptionHandlerTest extends AbstractWebMvcTest {
 
     @MockBean
+    private GalaxyService service;
+
+    @MockBean
     private GalaxyDtoValidator validator;
 
     @MockBean
-    private GalaxyService service;
+    private GalaxySpecificationBuilder specificationBuilder;
 
     @Test
     void testAppException() throws Exception {
@@ -81,7 +85,6 @@ class RestExceptionHandlerTest extends AbstractWebMvcTest {
         );
         // then
         verifyErrorResponse(response, ErrorCodeType.INVALID_CONTENT_TYPE);
-        then(validator).shouldHaveNoInteractions();
         then(service).shouldHaveNoInteractions();
     }
 
@@ -96,7 +99,6 @@ class RestExceptionHandlerTest extends AbstractWebMvcTest {
         );
         // then
         verifyErrorResponse(response, ErrorCodeType.INVALID_CONTENT_TYPE);
-        then(validator).shouldHaveNoInteractions();
         then(service).shouldHaveNoInteractions();
     }
 
@@ -106,7 +108,6 @@ class RestExceptionHandlerTest extends AbstractWebMvcTest {
         MockHttpServletResponse response = performRequest(post("/galaxy/add"));
         // then
         verifyErrorResponse(response, ErrorCodeType.INVALID_REQUEST_BODY);
-        then(validator).shouldHaveNoInteractions();
         then(service).shouldHaveNoInteractions();
     }
 
@@ -145,7 +146,6 @@ class RestExceptionHandlerTest extends AbstractWebMvcTest {
         );
         // then
         verifyErrorResponse(response, ErrorCodeType.ENTITY_MODIFIED);
-        then(validator).should().validate(dto, true);
         then(service).should().update(entity);
     }
 

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/GalaxyServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/GalaxyServiceTest.java
@@ -4,11 +4,10 @@ import com.example.universe.simulator.entityservice.common.utils.TestUtils;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.events.EventPublisher;
 import com.example.universe.simulator.entityservice.exception.AppException;
-import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
 import com.example.universe.simulator.entityservice.repositories.GalaxyRepository;
 import com.example.universe.simulator.entityservice.repositories.StarRepository;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
-import com.example.universe.simulator.entityservice.specifications.GalaxySpecification;
+import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
 import com.example.universe.simulator.entityservice.types.ErrorCodeType;
 import com.example.universe.simulator.entityservice.types.EventType;
 import org.junit.jupiter.api.Test;
@@ -57,7 +56,7 @@ class GalaxyServiceTest {
         );
         Pageable pageable = Pageable.unpaged();
         Page<Galaxy> page = new PageImpl<>(list, pageable, list.size());
-        Specification<Galaxy> specification = new GalaxySpecification().getSpecification(new GalaxyFilter());
+        Specification<Galaxy> specification = new GalaxySpecificationBuilder().build(null);
 
         given(repository.findAll(ArgumentMatchers.<Specification<Galaxy>>any(), any(Pageable.class)))
             .willReturn(page);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/MoonServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/MoonServiceTest.java
@@ -4,11 +4,10 @@ import com.example.universe.simulator.entityservice.common.utils.TestUtils;
 import com.example.universe.simulator.entityservice.entities.Moon;
 import com.example.universe.simulator.entityservice.events.EventPublisher;
 import com.example.universe.simulator.entityservice.exception.AppException;
-import com.example.universe.simulator.entityservice.filters.MoonFilter;
 import com.example.universe.simulator.entityservice.repositories.MoonRepository;
 import com.example.universe.simulator.entityservice.repositories.PlanetRepository;
 import com.example.universe.simulator.entityservice.services.MoonService;
-import com.example.universe.simulator.entityservice.specifications.MoonSpecification;
+import com.example.universe.simulator.entityservice.specifications.MoonSpecificationBuilder;
 import com.example.universe.simulator.entityservice.types.ErrorCodeType;
 import com.example.universe.simulator.entityservice.types.EventType;
 import org.junit.jupiter.api.Test;
@@ -57,7 +56,7 @@ class MoonServiceTest {
         );
         Pageable pageable = Pageable.unpaged();
         Page<Moon> page = new PageImpl<>(list, pageable, list.size());
-        Specification<Moon> specification = new MoonSpecification().getSpecification(new MoonFilter());
+        Specification<Moon> specification = new MoonSpecificationBuilder().build(null);
 
         given(repository.findAll(ArgumentMatchers.<Specification<Moon>>any(), any(Pageable.class)))
             .willReturn(page);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/PlanetServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/PlanetServiceTest.java
@@ -4,12 +4,11 @@ import com.example.universe.simulator.entityservice.common.utils.TestUtils;
 import com.example.universe.simulator.entityservice.entities.Planet;
 import com.example.universe.simulator.entityservice.events.EventPublisher;
 import com.example.universe.simulator.entityservice.exception.AppException;
-import com.example.universe.simulator.entityservice.filters.PlanetFilter;
 import com.example.universe.simulator.entityservice.repositories.MoonRepository;
 import com.example.universe.simulator.entityservice.repositories.PlanetRepository;
 import com.example.universe.simulator.entityservice.repositories.StarRepository;
 import com.example.universe.simulator.entityservice.services.PlanetService;
-import com.example.universe.simulator.entityservice.specifications.PlanetSpecification;
+import com.example.universe.simulator.entityservice.specifications.PlanetSpecificationBuilder;
 import com.example.universe.simulator.entityservice.types.ErrorCodeType;
 import com.example.universe.simulator.entityservice.types.EventType;
 import org.junit.jupiter.api.Test;
@@ -61,7 +60,7 @@ class PlanetServiceTest {
         );
         Pageable pageable = Pageable.unpaged();
         Page<Planet> page = new PageImpl<>(list, pageable, list.size());
-        Specification<Planet> specification = new PlanetSpecification().getSpecification(new PlanetFilter());
+        Specification<Planet> specification = new PlanetSpecificationBuilder().build(null);
 
         given(repository.findAll(ArgumentMatchers.<Specification<Planet>>any(), any(Pageable.class)))
             .willReturn(page);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/services/StarServiceTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/services/StarServiceTest.java
@@ -4,12 +4,11 @@ import com.example.universe.simulator.entityservice.common.utils.TestUtils;
 import com.example.universe.simulator.entityservice.entities.Star;
 import com.example.universe.simulator.entityservice.events.EventPublisher;
 import com.example.universe.simulator.entityservice.exception.AppException;
-import com.example.universe.simulator.entityservice.filters.StarFilter;
 import com.example.universe.simulator.entityservice.repositories.GalaxyRepository;
 import com.example.universe.simulator.entityservice.repositories.PlanetRepository;
 import com.example.universe.simulator.entityservice.repositories.StarRepository;
 import com.example.universe.simulator.entityservice.services.StarService;
-import com.example.universe.simulator.entityservice.specifications.StarSpecification;
+import com.example.universe.simulator.entityservice.specifications.StarSpecificationBuilder;
 import com.example.universe.simulator.entityservice.types.ErrorCodeType;
 import com.example.universe.simulator.entityservice.types.EventType;
 import org.junit.jupiter.api.Test;
@@ -61,7 +60,7 @@ class StarServiceTest {
         );
         Pageable pageable = Pageable.unpaged();
         Page<Star> page = new PageImpl<>(list, pageable, list.size());
-        Specification<Star> specification = new StarSpecification().getSpecification(new StarFilter());
+        Specification<Star> specification = new StarSpecificationBuilder().build(null);
 
         given(repository.findAll(ArgumentMatchers.<Specification<Star>>any(), any(Pageable.class)))
             .willReturn(page);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/specifications/AbstractSpecificationsTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/specifications/AbstractSpecificationsTest.java
@@ -1,0 +1,18 @@
+package com.example.universe.simulator.entityservice.unit.specifications;
+
+import com.example.universe.simulator.entityservice.specifications.AbstractSpecifications;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractSpecificationsTest {
+
+    @Test
+    void testLike() {
+        // when
+        Specification<?> result = AbstractSpecifications.like("property", "value");
+        // then
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/specifications/SpaceEntitySpecificationBuilderTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/specifications/SpaceEntitySpecificationBuilderTest.java
@@ -1,0 +1,52 @@
+package com.example.universe.simulator.entityservice.unit.specifications;
+
+import com.example.universe.simulator.entityservice.common.utils.TestUtils;
+import com.example.universe.simulator.entityservice.entities.Galaxy;
+import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
+import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.domain.Specification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Common space entity specification building is tested using GalaxySpecificationBuilder.
+ */
+@ExtendWith(MockitoExtension.class)
+class SpaceEntitySpecificationBuilderTest {
+
+    @InjectMocks
+    private GalaxySpecificationBuilder specificationBuilder;
+
+    @Test
+    void testBuild_nullFilter() {
+        // when
+        Specification<Galaxy> result = specificationBuilder.build(null);
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void testBuild_nullName() {
+        // given
+        GalaxyFilter filter = TestUtils.buildGalaxyFilter();
+        filter.setName(null);
+        // when
+        Specification<Galaxy> result = specificationBuilder.build(filter);
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void testBuild() {
+        // given
+        GalaxyFilter filter = TestUtils.buildGalaxyFilter();
+        // when
+        Specification<Galaxy> result = specificationBuilder.build(filter);
+        // then
+        assertThat(result).isNotNull();
+    }
+}


### PR DESCRIPTION
- renamed AbstractSpecification to AbstractSpecifications
- AbstractSpecifications is now public
- like method is now public in AbstractSpecifications
- renamed SpaceEntitySpecification to SpaceEntitySpecificationBuilder
- renamed getSpecification method to build in SpaceEntitySpecificationBuilder
- added null-safety in build method in SpaceEntitySpecificationBuilder
- renamed getCommonSpecification method to buildCommonSpecification in SpaceEntitySpecificationBuilder
- renamed getEntitySpecification method to buildEntitySpecification in SpaceEntitySpecificationBuilder
- renamed concrete XxxSpecification classes to XxxSpecificationBuilder
- concrete specification builder classes are now injectable @Component-s
- XxxSpecificationBuilder-s are now injected in controllers
- reworked specification creation logic in getList method in controllers
- added EqualsAndHashCode to filters
- added AbstractSpecificationsTest
- added SpaceEntitySpecificationBuilderTest
- reworked specification creation logic in testGetList method in service tests
- added testGetList_customPageable method in CommonControllerTest
- added testGetList_nullFilter method in controller tests
- reworked testGetList method in controller tests
- added filter builder methods in TestUtils
- removed validator interaction checks in RestExceptionHandlerTest
- added mockito-inline dependency to be able to mock/verify final methods in build.gradle