### PR TITLE
enabled tracing of all requests

### DIFF
--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -42,6 +42,7 @@ spring.rabbitmq.ssl.enabled=true
 spring.rabbitmq.ssl.trust-store=${server.ssl.key-store}
 spring.rabbitmq.ssl.trust-store-password=${US_KEYSTORE_PASSWORD}
 spring.rabbitmq.template.exchange=universe-simulator
+#sleuth
+spring.sleuth.sampler.probability=1.0
 #zipkin
-spring.zipkin.base-url=http://${zipkin-host}:${zipkin-port}
 spring.zipkin.sender.type=rabbit


### PR DESCRIPTION
- enabled tracing of all requests with the spring.sleuth.sampler.probability=1.0 property
- removed redundant spring.zipkin.base-url property