### PR TITLE
changed modelmapper to mapstruct

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ repositories {
 
 ext {
     set('commonVersion', '1.4.3')
-    set('modelmapperVersion', '3.1.0')
+    set('mapstructVersion', '1.5.2.Final')
     set('logstashLogbackEncoderVersion', '7.2')
     set('springBootAdminVersion', '2.7.2')
     set('springdocOpenapiVersion', '1.6.9')
@@ -115,7 +115,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation "org.modelmapper:modelmapper:${modelmapperVersion}"
+    implementation "org.mapstruct:mapstruct:${mapstructVersion}"
     implementation "org.springdoc:springdoc-openapi-data-rest:${springdocOpenapiVersion}"
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -140,4 +140,5 @@ dependencies {
     annotationProcessor 'org.hibernate:hibernate-jpamodelgen'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ def coverageExclusions = [
         '**/com/example/universe/simulator/entityservice/EntityServiceApplication.*',
         '**/com/example/universe/simulator/entityservice/config/SchedulingConfig.*',
         '**/com/example/universe/simulator/entityservice/entities/*_.*',
-        '**/com/example/universe/simulator/entityservice/config/AppProperties.*'
+        '**/com/example/universe/simulator/entityservice/config/AppProperties.*',
+        '**/com/example/universe/simulator/entityservice/mappers/*Impl.*'
 ]
 
 jacocoTestReport {
@@ -97,7 +98,7 @@ repositories {
 
 ext {
     set('commonVersion', '1.4.3')
-    set('modelmapperVersion', '3.1.0')
+    set('mapstructVersion', '1.5.2.Final')
     set('logstashLogbackEncoderVersion', '7.2')
     set('springBootAdminVersion', '2.7.2')
     set('springdocOpenapiVersion', '1.6.9')
@@ -115,7 +116,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation "org.modelmapper:modelmapper:${modelmapperVersion}"
+    implementation "org.mapstruct:mapstruct:${mapstructVersion}"
     implementation "org.springdoc:springdoc-openapi-data-rest:${springdocOpenapiVersion}"
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -140,4 +141,5 @@ dependencies {
     annotationProcessor 'org.hibernate:hibernate-jpamodelgen'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/config/BeanConfig.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/config/BeanConfig.java
@@ -1,6 +1,5 @@
 package com.example.universe.simulator.entityservice.config;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.boot.task.TaskExecutorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,10 +32,5 @@ public class BeanConfig {
     @Bean
     Clock clock() {
         return Clock.systemDefaultZone();
-    }
-
-    @Bean
-    ModelMapper modelMapper() {
-        return new ModelMapper();
     }
 }

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/GalaxyRestController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/GalaxyRestController.java
@@ -4,12 +4,12 @@ import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
+import com.example.universe.simulator.entityservice.mappers.GalaxyMapper;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
 import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.GalaxyDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +36,7 @@ public class GalaxyRestController {
     private final GalaxyService service;
     private final GalaxyDtoValidator validator;
     private final GalaxySpecificationBuilder specificationBuilder;
-    private final ModelMapper modelMapper;
+    private final GalaxyMapper mapper;
 
     @GetMapping
     public Callable<Page<GalaxyDto>> getList(@RequestParam(required = false) String name, @ParameterObject Pageable pageable) {
@@ -48,7 +48,7 @@ public class GalaxyRestController {
 
         return () -> {
             Page<GalaxyDto> result = service.getList(specification, pageable)
-                .map(item -> modelMapper.map(item, GalaxyDto.class));
+                .map(mapper::toDto);
             log.info("fetched [{}] record(s)", result.getNumberOfElements());
 
             return result;
@@ -58,7 +58,7 @@ public class GalaxyRestController {
     @GetMapping("{id}")
     public GalaxyDto get(@PathVariable UUID id) throws AppException {
         log.info("calling get with id [{}]", id);
-        GalaxyDto result = modelMapper.map(service.get(id), GalaxyDto.class);
+        GalaxyDto result = mapper.toDto(service.get(id));
         log.info("fetched [{}]", result.getId());
 
         return result;
@@ -69,8 +69,8 @@ public class GalaxyRestController {
         log.info("calling add with {}", dto);
         validator.validate(dto, false);
 
-        Galaxy entity = modelMapper.map(dto, Galaxy.class);
-        GalaxyDto result = modelMapper.map(service.add(entity), GalaxyDto.class);
+        Galaxy entity = mapper.toEntity(dto);
+        GalaxyDto result = mapper.toDto(service.add(entity));
         log.info("added [{}]", result.getId());
 
         return result;
@@ -81,8 +81,8 @@ public class GalaxyRestController {
         log.info("calling update with {}", dto);
         validator.validate(dto, true);
 
-        Galaxy entity = modelMapper.map(dto, Galaxy.class);
-        GalaxyDto result = modelMapper.map(service.update(entity), GalaxyDto.class);
+        Galaxy entity = mapper.toEntity(dto);
+        GalaxyDto result = mapper.toDto(service.update(entity));
         log.info("updated [{}]", result.getId());
 
         return result;

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/MoonRestController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/MoonRestController.java
@@ -4,12 +4,12 @@ import com.example.universe.simulator.entityservice.dtos.MoonDto;
 import com.example.universe.simulator.entityservice.entities.Moon;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.MoonFilter;
+import com.example.universe.simulator.entityservice.mappers.MoonMapper;
 import com.example.universe.simulator.entityservice.services.MoonService;
 import com.example.universe.simulator.entityservice.specifications.MoonSpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.MoonDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +36,7 @@ public class MoonRestController {
     private final MoonService service;
     private final MoonDtoValidator validator;
     private final MoonSpecificationBuilder specificationBuilder;
-    private final ModelMapper modelMapper;
+    private final MoonMapper mapper;
 
     @GetMapping
     public Callable<Page<MoonDto>> getList(@RequestParam(required = false) String name, @ParameterObject Pageable pageable) {
@@ -48,7 +48,7 @@ public class MoonRestController {
 
         return () -> {
             Page<MoonDto> result = service.getList(specification, pageable)
-                .map(item -> modelMapper.map(item, MoonDto.class));
+                .map(mapper::toDto);
             log.info("fetched [{}] record(s)", result.getNumberOfElements());
 
             return result;
@@ -58,7 +58,7 @@ public class MoonRestController {
     @GetMapping("{id}")
     public MoonDto get(@PathVariable UUID id) throws AppException {
         log.info("calling get with id [{}]", id);
-        MoonDto result = modelMapper.map(service.get(id), MoonDto.class);
+        MoonDto result = mapper.toDto(service.get(id));
         log.info("fetched [{}]", result.getId());
 
         return result;
@@ -69,8 +69,8 @@ public class MoonRestController {
         log.info("calling add with {}, planet id [{}]", dto, dto.getPlanet().getId());
         validator.validate(dto, false);
 
-        Moon entity = modelMapper.map(dto, Moon.class);
-        MoonDto result = modelMapper.map(service.add(entity), MoonDto.class);
+        Moon entity = mapper.toEntity(dto);
+        MoonDto result = mapper.toDto(service.add(entity));
         log.info("added [{}]", result.getId());
 
         return result;
@@ -81,8 +81,8 @@ public class MoonRestController {
         log.info("calling update with {}, planet id [{}]", dto, dto.getPlanet().getId());
         validator.validate(dto, true);
 
-        Moon entity = modelMapper.map(dto, Moon.class);
-        MoonDto result = modelMapper.map(service.update(entity), MoonDto.class);
+        Moon entity = mapper.toEntity(dto);
+        MoonDto result = mapper.toDto(service.update(entity));
         log.info("updated [{}]", result.getId());
 
         return result;

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/PlanetRestController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/PlanetRestController.java
@@ -4,12 +4,12 @@ import com.example.universe.simulator.entityservice.dtos.PlanetDto;
 import com.example.universe.simulator.entityservice.entities.Planet;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.PlanetFilter;
+import com.example.universe.simulator.entityservice.mappers.PlanetMapper;
 import com.example.universe.simulator.entityservice.services.PlanetService;
 import com.example.universe.simulator.entityservice.specifications.PlanetSpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.PlanetDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +36,7 @@ public class PlanetRestController {
     private final PlanetService service;
     private final PlanetDtoValidator validator;
     private final PlanetSpecificationBuilder specificationBuilder;
-    private final ModelMapper modelMapper;
+    private final PlanetMapper mapper;
 
     @GetMapping
     public Callable<Page<PlanetDto>> getList(@RequestParam(required = false) String name, @ParameterObject Pageable pageable) {
@@ -48,7 +48,7 @@ public class PlanetRestController {
 
         return () -> {
             Page<PlanetDto> result = service.getList(specification, pageable)
-                .map(item -> modelMapper.map(item, PlanetDto.class));
+                .map(mapper::toDto);
             log.info("fetched [{}] record(s)", result.getNumberOfElements());
 
             return result;
@@ -58,7 +58,7 @@ public class PlanetRestController {
     @GetMapping("{id}")
     public PlanetDto get(@PathVariable UUID id) throws AppException {
         log.info("calling get with id [{}]", id);
-        PlanetDto result = modelMapper.map(service.get(id), PlanetDto.class);
+        PlanetDto result = mapper.toDto(service.get(id));
         log.info("fetched [{}]", result.getId());
 
         return result;
@@ -69,8 +69,8 @@ public class PlanetRestController {
         log.info("calling add with {}, star id [{}]", dto, dto.getStar().getId());
         validator.validate(dto, false);
 
-        Planet entity = modelMapper.map(dto, Planet.class);
-        PlanetDto result = modelMapper.map(service.add(entity), PlanetDto.class);
+        Planet entity = mapper.toEntity(dto);
+        PlanetDto result = mapper.toDto(service.add(entity));
         log.info("added [{}]", result.getId());
 
         return result;
@@ -81,8 +81,8 @@ public class PlanetRestController {
         log.info("calling update with {}, star id [{}]", dto, dto.getStar().getId());
         validator.validate(dto, true);
 
-        Planet entity = modelMapper.map(dto, Planet.class);
-        PlanetDto result = modelMapper.map(service.update(entity), PlanetDto.class);
+        Planet entity = mapper.toEntity(dto);
+        PlanetDto result = mapper.toDto(service.update(entity));
         log.info("updated [{}]", result.getId());
 
         return result;

--- a/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/StarRestController.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/controllers/rest/StarRestController.java
@@ -4,12 +4,12 @@ import com.example.universe.simulator.entityservice.dtos.StarDto;
 import com.example.universe.simulator.entityservice.entities.Star;
 import com.example.universe.simulator.entityservice.exception.AppException;
 import com.example.universe.simulator.entityservice.filters.StarFilter;
+import com.example.universe.simulator.entityservice.mappers.StarMapper;
 import com.example.universe.simulator.entityservice.services.StarService;
 import com.example.universe.simulator.entityservice.specifications.StarSpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.StarDtoValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +36,7 @@ public class StarRestController {
     private final StarService service;
     private final StarDtoValidator validator;
     private final StarSpecificationBuilder specificationBuilder;
-    private final ModelMapper modelMapper;
+    private final StarMapper mapper;
 
     @GetMapping
     public Callable<Page<StarDto>> getList(@RequestParam(required = false) String name, @ParameterObject Pageable pageable) {
@@ -48,7 +48,7 @@ public class StarRestController {
 
         return () -> {
             Page<StarDto> result = service.getList(specification, pageable)
-                .map(item -> modelMapper.map(item, StarDto.class));
+                .map(mapper::toDto);
             log.info("fetched [{}] record(s)", result.getNumberOfElements());
 
             return result;
@@ -58,7 +58,7 @@ public class StarRestController {
     @GetMapping("{id}")
     public StarDto get(@PathVariable UUID id) throws AppException {
         log.info("calling get with id [{}]", id);
-        StarDto result = modelMapper.map(service.get(id), StarDto.class);
+        StarDto result = mapper.toDto(service.get(id));
         log.info("fetched [{}]", result.getId());
 
         return result;
@@ -69,8 +69,8 @@ public class StarRestController {
         log.info("calling add with {}, galaxy id [{}]", dto, dto.getGalaxy().getId());
         validator.validate(dto, false);
 
-        Star entity = modelMapper.map(dto, Star.class);
-        StarDto result = modelMapper.map(service.add(entity), StarDto.class);
+        Star entity = mapper.toEntity(dto);
+        StarDto result = mapper.toDto(service.add(entity));
         log.info("added [{}]", result.getId());
 
         return result;
@@ -81,8 +81,8 @@ public class StarRestController {
         log.info("calling update with {}, galaxy id [{}]", dto, dto.getGalaxy().getId());
         validator.validate(dto, true);
 
-        Star entity = modelMapper.map(dto, Star.class);
-        StarDto result = modelMapper.map(service.update(entity), StarDto.class);
+        Star entity = mapper.toEntity(dto);
+        StarDto result = mapper.toDto(service.update(entity));
         log.info("updated [{}]", result.getId());
 
         return result;

--- a/src/main/java/com/example/universe/simulator/entityservice/mappers/GalaxyMapper.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/mappers/GalaxyMapper.java
@@ -1,0 +1,13 @@
+package com.example.universe.simulator.entityservice.mappers;
+
+import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
+import com.example.universe.simulator.entityservice.entities.Galaxy;
+import org.mapstruct.Mapper;
+
+@Mapper(config = MappingConfig.class)
+public interface GalaxyMapper {
+
+    GalaxyDto toDto(Galaxy entity);
+
+    Galaxy toEntity(GalaxyDto dto);
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/mappers/MappingConfig.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/mappers/MappingConfig.java
@@ -1,0 +1,6 @@
+package com.example.universe.simulator.entityservice.mappers;
+
+import org.mapstruct.MapperConfig;
+
+@MapperConfig(componentModel = "spring")
+public interface MappingConfig {}

--- a/src/main/java/com/example/universe/simulator/entityservice/mappers/MoonMapper.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/mappers/MoonMapper.java
@@ -1,0 +1,13 @@
+package com.example.universe.simulator.entityservice.mappers;
+
+import com.example.universe.simulator.entityservice.dtos.MoonDto;
+import com.example.universe.simulator.entityservice.entities.Moon;
+import org.mapstruct.Mapper;
+
+@Mapper(config = MappingConfig.class, uses = PlanetMapper.class)
+public interface MoonMapper {
+
+    MoonDto toDto(Moon entity);
+
+    Moon toEntity(MoonDto dto);
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/mappers/PlanetMapper.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/mappers/PlanetMapper.java
@@ -1,0 +1,13 @@
+package com.example.universe.simulator.entityservice.mappers;
+
+import com.example.universe.simulator.entityservice.dtos.PlanetDto;
+import com.example.universe.simulator.entityservice.entities.Planet;
+import org.mapstruct.Mapper;
+
+@Mapper(config = MappingConfig.class, uses = StarMapper.class)
+public interface PlanetMapper {
+
+    PlanetDto toDto(Planet entity);
+
+    Planet toEntity(PlanetDto dto);
+}

--- a/src/main/java/com/example/universe/simulator/entityservice/mappers/StarMapper.java
+++ b/src/main/java/com/example/universe/simulator/entityservice/mappers/StarMapper.java
@@ -1,0 +1,13 @@
+package com.example.universe.simulator.entityservice.mappers;
+
+import com.example.universe.simulator.entityservice.dtos.StarDto;
+import com.example.universe.simulator.entityservice.entities.Star;
+import org.mapstruct.Mapper;
+
+@Mapper(config = MappingConfig.class, uses = GalaxyMapper.class)
+public interface StarMapper {
+
+    StarDto toDto(Star entity);
+
+    Star toEntity(StarDto dto);
+}

--- a/src/test/java/com/example/universe/simulator/entityservice/common/abstractions/AbstractMockMvcTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/common/abstractions/AbstractMockMvcTest.java
@@ -4,7 +4,6 @@ import com.example.universe.simulator.common.dtos.ErrorDto;
 import com.example.universe.simulator.entityservice.types.ErrorCodeType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -24,9 +23,6 @@ public abstract class AbstractMockMvcTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
-
-    @Autowired
-    protected ModelMapper modelMapper;
 
     /*
      * Handles sync and async requests. For async requests, see

--- a/src/test/java/com/example/universe/simulator/entityservice/common/abstractions/AbstractWebMvcTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/common/abstractions/AbstractWebMvcTest.java
@@ -1,9 +1,7 @@
 package com.example.universe.simulator.entityservice.common.abstractions;
 
 import com.example.universe.simulator.common.test.AbstractTest;
-import com.example.universe.simulator.entityservice.config.BeanConfig;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -12,7 +10,6 @@ import java.io.UnsupportedEncodingException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @AbstractTest
-@Import(BeanConfig.class)
 public abstract class AbstractWebMvcTest extends AbstractMockMvcTest {
 
     protected final void verifyOkStatus(int status) {

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/GalaxyIntegrationTest.java
@@ -3,6 +3,7 @@ package com.example.universe.simulator.entityservice.integration;
 import com.example.universe.simulator.entityservice.common.utils.JsonPage;
 import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
+import com.example.universe.simulator.entityservice.mappers.GalaxyMapper;
 import com.example.universe.simulator.entityservice.repositories.GalaxyRepository;
 import com.example.universe.simulator.entityservice.types.EventType;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -30,20 +31,16 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private GalaxyRepository galaxyRepository;
 
+    @Autowired
+    private GalaxyMapper mapper;
+
     private GalaxyDto galaxy1;
     private GalaxyDto galaxy2;
 
     @BeforeEach
     void setup() {
-        galaxy1 = modelMapper.map(
-            galaxyRepository.save(Galaxy.builder().name("name1").build()),
-            GalaxyDto.class
-        );
-
-        galaxy2 = modelMapper.map(
-            galaxyRepository.save(Galaxy.builder().name("name2").build()),
-            GalaxyDto.class
-        );
+        galaxy1 = mapper.toDto(galaxyRepository.save(Galaxy.builder().name("name1").build()));
+        galaxy2 = mapper.toDto(galaxyRepository.save(Galaxy.builder().name("name2").build()));
     }
 
     @AfterEach
@@ -158,7 +155,7 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<GalaxyDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(id, Galaxy.class))
-            .map(item -> modelMapper.map(item, GalaxyDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(galaxy1);
     }
@@ -189,7 +186,7 @@ class GalaxyIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<GalaxyDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(galaxy1.getId(), Galaxy.class))
-            .map(item -> modelMapper.map(item, GalaxyDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(galaxy1);
     }

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/MoonIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/MoonIntegrationTest.java
@@ -8,6 +8,7 @@ import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.entities.Moon;
 import com.example.universe.simulator.entityservice.entities.Planet;
 import com.example.universe.simulator.entityservice.entities.Star;
+import com.example.universe.simulator.entityservice.mappers.MoonMapper;
 import com.example.universe.simulator.entityservice.repositories.GalaxyRepository;
 import com.example.universe.simulator.entityservice.repositories.MoonRepository;
 import com.example.universe.simulator.entityservice.repositories.PlanetRepository;
@@ -48,6 +49,9 @@ class MoonIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private MoonRepository moonRepository;
 
+    @Autowired
+    private MoonMapper mapper;
+
     private Planet planet;
     private MoonDto moon1;
     private MoonDto moon2;
@@ -64,15 +68,8 @@ class MoonIntegrationTest extends AbstractIntegrationTest {
         planet.setStar(star);
         planet = planetRepository.save(planet);
 
-        moon1 = modelMapper.map(
-            moonRepository.save(Moon.builder().name("name1").planet(planet).build()),
-            MoonDto.class
-        );
-
-        moon2 = modelMapper.map(
-            moonRepository.save(Moon.builder().name("name2").planet(planet).build()),
-            MoonDto.class
-        );
+        moon1 = mapper.toDto(moonRepository.save(Moon.builder().name("name1").planet(planet).build()));
+        moon2 = mapper.toDto(moonRepository.save(Moon.builder().name("name2").planet(planet).build()));
     }
 
     @AfterEach
@@ -196,7 +193,7 @@ class MoonIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<MoonDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(id, Moon.class))
-            .map(item -> modelMapper.map(item, MoonDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(moon1);
     }
@@ -227,7 +224,7 @@ class MoonIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<MoonDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(moon1.getId(), Moon.class))
-            .map(item -> modelMapper.map(item, MoonDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(moon1);
     }

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/PlanetIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/PlanetIntegrationTest.java
@@ -7,6 +7,7 @@ import com.example.universe.simulator.entityservice.dtos.StarDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.entities.Planet;
 import com.example.universe.simulator.entityservice.entities.Star;
+import com.example.universe.simulator.entityservice.mappers.PlanetMapper;
 import com.example.universe.simulator.entityservice.repositories.GalaxyRepository;
 import com.example.universe.simulator.entityservice.repositories.PlanetRepository;
 import com.example.universe.simulator.entityservice.repositories.StarRepository;
@@ -43,6 +44,9 @@ class PlanetIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private PlanetRepository planetRepository;
 
+    @Autowired
+    private PlanetMapper mapper;
+
     private Star star;
     private PlanetDto planet1;
     private PlanetDto planet2;
@@ -55,15 +59,8 @@ class PlanetIntegrationTest extends AbstractIntegrationTest {
         star.setGalaxy(galaxy);
         star = starRepository.save(star);
 
-        planet1 = modelMapper.map(
-            planetRepository.save(Planet.builder().name("name1").star(star).build()),
-            PlanetDto.class
-        );
-
-        planet2 = modelMapper.map(
-            planetRepository.save(Planet.builder().name("name2").star(star).build()),
-            PlanetDto.class
-        );
+        planet1 = mapper.toDto(planetRepository.save(Planet.builder().name("name1").star(star).build()));
+        planet2 = mapper.toDto(planetRepository.save(Planet.builder().name("name2").star(star).build()));
     }
 
     @AfterEach
@@ -186,7 +183,7 @@ class PlanetIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<PlanetDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(id, Planet.class))
-            .map(item -> modelMapper.map(item, PlanetDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(planet1);
     }
@@ -217,7 +214,7 @@ class PlanetIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<PlanetDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(planet1.getId(), Planet.class))
-            .map(item -> modelMapper.map(item, PlanetDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(planet1);
     }

--- a/src/test/java/com/example/universe/simulator/entityservice/integration/StarIntegrationTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/integration/StarIntegrationTest.java
@@ -6,6 +6,7 @@ import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.dtos.StarDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.entities.Star;
+import com.example.universe.simulator.entityservice.mappers.StarMapper;
 import com.example.universe.simulator.entityservice.repositories.GalaxyRepository;
 import com.example.universe.simulator.entityservice.repositories.StarRepository;
 import com.example.universe.simulator.entityservice.types.EventType;
@@ -37,6 +38,9 @@ class StarIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private StarRepository starRepository;
 
+    @Autowired
+    private StarMapper mapper;
+
     private Galaxy galaxy;
     private StarDto star1;
     private StarDto star2;
@@ -45,15 +49,8 @@ class StarIntegrationTest extends AbstractIntegrationTest {
     void setup() {
         galaxy = galaxyRepository.save(TestUtils.buildGalaxyForAdd());
 
-        star1 = modelMapper.map(
-            starRepository.save(Star.builder().name("name1").galaxy(galaxy).build()),
-            StarDto.class
-        );
-
-        star2 = modelMapper.map(
-            starRepository.save(Star.builder().name("name2").galaxy(galaxy).build()),
-            StarDto.class
-        );
+        star1 = mapper.toDto(starRepository.save(Star.builder().name("name1").galaxy(galaxy).build()));
+        star2 = mapper.toDto(starRepository.save(Star.builder().name("name2").galaxy(galaxy).build()));
     }
 
     @AfterEach
@@ -175,7 +172,7 @@ class StarIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<StarDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(id, Star.class))
-            .map(item -> modelMapper.map(item, StarDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(star1);
     }
@@ -206,7 +203,7 @@ class StarIntegrationTest extends AbstractIntegrationTest {
         // then
         Optional<StarDto> cache = Optional.ofNullable(cacheManager.getCache(CACHE_NAME))
             .map(item -> item.get(star1.getId(), Star.class))
-            .map(item -> modelMapper.map(item, StarDto.class));
+            .map(mapper::toDto);
         assertThat(cache)
             .hasValue(star1);
     }

--- a/src/test/java/com/example/universe/simulator/entityservice/smoke/BeanConfigSmokeTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/smoke/BeanConfigSmokeTest.java
@@ -1,7 +1,6 @@
 package com.example.universe.simulator.entityservice.smoke;
 
 import org.junit.jupiter.api.Test;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -23,9 +22,6 @@ class BeanConfigSmokeTest extends AbstractSmokeTest {
     @Autowired
     private Clock clock;
 
-    @Autowired
-    private ModelMapper modelMapper;
-
     @Test
     void test() {
         // applicationTaskExecutor
@@ -41,8 +37,5 @@ class BeanConfigSmokeTest extends AbstractSmokeTest {
 
         // clock
         assertThat(clock).isEqualTo(Clock.systemDefaultZone());
-
-        // modelMapper
-        assertThat(modelMapper).isNotNull();
     }
 }

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/rest/CommonRestControllerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/rest/CommonRestControllerTest.java
@@ -5,12 +5,15 @@ import com.example.universe.simulator.entityservice.common.utils.TestUtils;
 import com.example.universe.simulator.entityservice.controllers.rest.GalaxyRestController;
 import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
+import com.example.universe.simulator.entityservice.mappers.GalaxyMapperImpl;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
 import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.GalaxyDtoValidator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 // Common controller cases are tested using GalaxyController.
 @WebMvcTest(GalaxyRestController.class)
+@Import(GalaxyMapperImpl.class)
 class CommonRestControllerTest extends AbstractWebMvcTest {
 
     @MockBean
@@ -36,6 +40,9 @@ class CommonRestControllerTest extends AbstractWebMvcTest {
     @MockBean
     private GalaxySpecificationBuilder specificationBuilder;
 
+    @SpyBean
+    private GalaxyMapperImpl mapper;
+
     @Test
     void testGetList_defaultPageable() throws Exception {
         // given
@@ -45,7 +52,7 @@ class CommonRestControllerTest extends AbstractWebMvcTest {
 
         Pageable pageable = TestUtils.getDefaultPageable();
         Page<Galaxy> entityPage = new PageImpl<>(entityList, pageable, entityList.size());
-        Page<GalaxyDto> dtoPage = entityPage.map(item -> modelMapper.map(item, GalaxyDto.class));
+        Page<GalaxyDto> dtoPage = entityPage.map(mapper::toDto);
 
         given(service.getList(any(), any())).willReturn(entityPage);
         // when
@@ -64,7 +71,7 @@ class CommonRestControllerTest extends AbstractWebMvcTest {
 
         Pageable pageable = TestUtils.getSpaceEntityPageable();
         Page<Galaxy> entityPage = new PageImpl<>(entityList, pageable, entityList.size());
-        Page<GalaxyDto> dtoPage = entityPage.map(item -> modelMapper.map(item, GalaxyDto.class));
+        Page<GalaxyDto> dtoPage = entityPage.map(mapper::toDto);
 
         given(service.getList(any(), any())).willReturn(entityPage);
         // when

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/rest/GalaxyRestControllerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/rest/GalaxyRestControllerTest.java
@@ -6,12 +6,16 @@ import com.example.universe.simulator.entityservice.controllers.rest.GalaxyRestC
 import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.filters.GalaxyFilter;
+import com.example.universe.simulator.entityservice.mappers.GalaxyMapper;
+import com.example.universe.simulator.entityservice.mappers.GalaxyMapperImpl;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
 import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.GalaxyDtoValidator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +33,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @WebMvcTest(GalaxyRestController.class)
+@Import(GalaxyMapperImpl.class)
 class GalaxyRestControllerTest extends AbstractWebMvcTest {
 
     @MockBean
@@ -40,6 +45,9 @@ class GalaxyRestControllerTest extends AbstractWebMvcTest {
     @MockBean
     private GalaxySpecificationBuilder specificationBuilder;
 
+    @SpyBean
+    private GalaxyMapper mapper;
+
     @Test
     void testGetList() throws Exception {
         // given
@@ -50,7 +58,7 @@ class GalaxyRestControllerTest extends AbstractWebMvcTest {
         GalaxyFilter filter = TestUtils.buildGalaxyFilter();
         Pageable pageable = TestUtils.getDefaultPageable();
         Page<Galaxy> entityPage = new PageImpl<>(entityList, pageable, entityList.size());
-        Page<GalaxyDto> dtoPage = entityPage.map(item -> modelMapper.map(item, GalaxyDto.class));
+        Page<GalaxyDto> dtoPage = entityPage.map(mapper::toDto);
 
         given(service.getList(any(), any())).willReturn(entityPage);
         // when
@@ -68,7 +76,7 @@ class GalaxyRestControllerTest extends AbstractWebMvcTest {
         // given
         UUID id = UUID.randomUUID();
         Galaxy entity = TestUtils.buildGalaxy();
-        GalaxyDto dto = modelMapper.map(entity, GalaxyDto.class);
+        GalaxyDto dto = mapper.toDto(entity);
         given(service.get(any())).willReturn(entity);
         // when
         MockHttpServletResponse response = performRequest(get("/galaxies/{id}", id));
@@ -81,8 +89,8 @@ class GalaxyRestControllerTest extends AbstractWebMvcTest {
     void testAdd() throws Exception {
         // given
         GalaxyDto inputDto = TestUtils.buildGalaxyDtoForAdd();
-        Galaxy entity = modelMapper.map(inputDto, Galaxy.class);
-        GalaxyDto resultDto = modelMapper.map(entity, GalaxyDto.class);
+        Galaxy entity = mapper.toEntity(inputDto);
+        GalaxyDto resultDto = mapper.toDto(entity);
         given(service.add(any())).willReturn(entity);
         // when
         MockHttpServletResponse response = performRequestWithBody(post("/galaxies"), inputDto);
@@ -96,8 +104,8 @@ class GalaxyRestControllerTest extends AbstractWebMvcTest {
     void testUpdate() throws Exception {
         // given
         GalaxyDto inputDto = TestUtils.buildGalaxyDtoForUpdate();
-        Galaxy entity = modelMapper.map(inputDto, Galaxy.class);
-        GalaxyDto resultDto = modelMapper.map(entity, GalaxyDto.class);
+        Galaxy entity = mapper.toEntity(inputDto);
+        GalaxyDto resultDto = mapper.toDto(entity);
         given(service.update(any())).willReturn(entity);
         // when
         MockHttpServletResponse response = performRequestWithBody(put("/galaxies"), inputDto);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/rest/StarRestControllerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/controllers/rest/StarRestControllerTest.java
@@ -6,12 +6,17 @@ import com.example.universe.simulator.entityservice.controllers.rest.StarRestCon
 import com.example.universe.simulator.entityservice.dtos.StarDto;
 import com.example.universe.simulator.entityservice.entities.Star;
 import com.example.universe.simulator.entityservice.filters.StarFilter;
+import com.example.universe.simulator.entityservice.mappers.GalaxyMapperImpl;
+import com.example.universe.simulator.entityservice.mappers.StarMapper;
+import com.example.universe.simulator.entityservice.mappers.StarMapperImpl;
 import com.example.universe.simulator.entityservice.services.StarService;
 import com.example.universe.simulator.entityservice.specifications.StarSpecificationBuilder;
 import com.example.universe.simulator.entityservice.validators.StarDtoValidator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +34,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @WebMvcTest(StarRestController.class)
+@Import({GalaxyMapperImpl.class, StarMapperImpl.class})
 class StarRestControllerTest extends AbstractWebMvcTest {
 
     @MockBean
@@ -40,6 +46,9 @@ class StarRestControllerTest extends AbstractWebMvcTest {
     @MockBean
     private StarSpecificationBuilder specificationBuilder;
 
+    @SpyBean
+    private StarMapper mapper;
+
     @Test
     void testGetList() throws Exception {
         // given
@@ -50,7 +59,7 @@ class StarRestControllerTest extends AbstractWebMvcTest {
         StarFilter filter = TestUtils.buildStarFilter();
         Pageable pageable = TestUtils.getDefaultPageable();
         Page<Star> entityPage = new PageImpl<>(entityList, pageable, entityList.size());
-        Page<StarDto> dtoPage = entityPage.map(item -> modelMapper.map(item, StarDto.class));
+        Page<StarDto> dtoPage = entityPage.map(mapper::toDto);
 
         given(service.getList(any(), any())).willReturn(entityPage);
         // when
@@ -68,7 +77,7 @@ class StarRestControllerTest extends AbstractWebMvcTest {
         // given
         UUID id = UUID.randomUUID();
         Star entity = TestUtils.buildStar();
-        StarDto dto = modelMapper.map(entity, StarDto.class);
+        StarDto dto = mapper.toDto(entity);
         given(service.get(any())).willReturn(entity);
         // when
         MockHttpServletResponse response = performRequest(get("/stars/{id}", id));
@@ -81,8 +90,8 @@ class StarRestControllerTest extends AbstractWebMvcTest {
     void testAdd() throws Exception {
         // given
         StarDto inputDto = TestUtils.buildStarDtoForAdd();
-        Star entity = modelMapper.map(inputDto, Star.class);
-        StarDto resultDto = modelMapper.map(entity, StarDto.class);
+        Star entity = mapper.toEntity(inputDto);
+        StarDto resultDto = mapper.toDto(entity);
         given(service.add(any())).willReturn(entity);
         // when
         MockHttpServletResponse response = performRequestWithBody(post("/stars"), inputDto);
@@ -96,8 +105,8 @@ class StarRestControllerTest extends AbstractWebMvcTest {
     void testUpdate() throws Exception {
         // given
         StarDto inputDto = TestUtils.buildStarDtoForUpdate();
-        Star entity = modelMapper.map(inputDto, Star.class);
-        StarDto resultDto = modelMapper.map(entity, StarDto.class);
+        Star entity = mapper.toEntity(inputDto);
+        StarDto resultDto = mapper.toDto(entity);
         given(service.update(any())).willReturn(entity);
         // when
         MockHttpServletResponse response = performRequestWithBody(put("/stars"), inputDto);

--- a/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/com/example/universe/simulator/entityservice/unit/exception/RestExceptionHandlerTest.java
@@ -6,6 +6,7 @@ import com.example.universe.simulator.entityservice.controllers.rest.GalaxyRestC
 import com.example.universe.simulator.entityservice.dtos.GalaxyDto;
 import com.example.universe.simulator.entityservice.entities.Galaxy;
 import com.example.universe.simulator.entityservice.exception.AppException;
+import com.example.universe.simulator.entityservice.mappers.GalaxyMapperImpl;
 import com.example.universe.simulator.entityservice.services.GalaxyService;
 import com.example.universe.simulator.entityservice.specifications.GalaxySpecificationBuilder;
 import com.example.universe.simulator.entityservice.types.ErrorCodeType;
@@ -13,6 +14,8 @@ import com.example.universe.simulator.entityservice.validators.GalaxyDtoValidato
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -37,6 +40,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 // Exception handling is tested using GalaxyController.
 @WebMvcTest(GalaxyRestController.class)
+@Import(GalaxyMapperImpl.class)
 class RestExceptionHandlerTest extends AbstractWebMvcTest {
 
     @MockBean
@@ -47,6 +51,9 @@ class RestExceptionHandlerTest extends AbstractWebMvcTest {
 
     @MockBean
     private GalaxySpecificationBuilder specificationBuilder;
+
+    @SpyBean
+    private GalaxyMapperImpl mapper;
 
     @Test
     void testAppException() throws Exception {
@@ -135,7 +142,7 @@ class RestExceptionHandlerTest extends AbstractWebMvcTest {
     void testObjectOptimisticLockingFailureException() throws Exception {
         // given
         GalaxyDto dto = TestUtils.buildGalaxyDtoForUpdate();
-        Galaxy entity = modelMapper.map(dto, Galaxy.class);
+        Galaxy entity = mapper.toEntity(dto);
         given(service.update(any())).willThrow(ObjectOptimisticLockingFailureException.class);
         // when
         MockHttpServletResponse response = performRequestWithBody(put("/galaxies"), dto);


### PR DESCRIPTION
- removed modelmapperVersion property in build.gradle
- added mapstructVersion property in build.gradle
- removed modelmapper dependency
- added mapstruct & mapstruct-processor dependencies
- removed modelMapper bean in BeanConfig
- removed modelMapper field & test in BeanConfigSmokeTest
- removed modelMapper field in AbstractMockMvcTest
- removed BeanConfig configuration import in AbstractWebMvcTest
- added MappingConfig interface
- added mapper interfaces
- replaced modelMapper field with mapper in rest controllers
- added mapper implementation bean import & mapper field in rest controller tests
- added mapper field in integration tests
- added mapper implementation classes to jacoco exclusions